### PR TITLE
added delimiter to genclone show

### DIFF
--- a/R/methods.r
+++ b/R/methods.r
@@ -604,12 +604,12 @@ setMethod(
     if (strata == 0) popstrata <- "strata."
     popdef  <- ifelse(npop > 0, "defined -", "defined.")
     cat("Population information:\n\n")
-    cat("", ltab[4], strata, popstrata, stratanames, fill = TRUE)
+    cat("", ltab[4], strata, popstrata, paste(stratanames, collapse = ", "), fill = TRUE)
     if (!is.null(object@hierarchy)){
       cat("", ltab[5], "1", "hierarchy -", 
           paste(object@hierarchy, collapse = ""), fill = TRUE)
     }
-    cat("", ltab[6], npop, "populations", popdef, pops, fill = TRUE)
+    cat("", ltab[6], npop, "populations", popdef, paste(pops, collapse = ", "), fill = TRUE)
     
   })
 


### PR DESCRIPTION
The `show` method for the genclone object prints useful information including the strata and population names. However, this information is not delimited which could potentially create confusion. For example:

    data("Pinf", package = "poppr")
    Pinf

Prints

    ## This is a genclone object
    ...
    ##     2 strata - Continent Country
    ##     2 populations defined - South America North America

I feel this leaves the population names ambiguous as they could be interpreted as 4 names. Adding a delimiter would result in

    ##     2 strata - Continent, Country
    ##     2 populations defined - South America, North America

which makes it a little more clear that there are two populations and what their names are. This PR adds a delimiter to the show method for genclone.