### PR TITLE
Initialize snpclone mlg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: poppr
 Type: Package
 Title: Genetic Analysis of Populations with Mixed Reproduction
-Version: 2.3.0.99-45
-Date: 2017-03-31
+Version: 2.3.0.99-52
+Date: 2017-04-02
 Authors@R: c(person(c("Zhian", "N."), "Kamvar", role = c("cre", "aut"),
     email = "zkamvar@gmail.com"),
     person(c("Javier", "F."), "Tabima", role = "aut",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: poppr
 Type: Package
 Title: Genetic Analysis of Populations with Mixed Reproduction
-Version: 2.3.0.99-52
-Date: 2017-04-02
+Version: 2.3.0.99-47
+Date: 2017-04-03
 Authors@R: c(person(c("Zhian", "N."), "Kamvar", role = c("cre", "aut"),
     email = "zkamvar@gmail.com"),
     person(c("Javier", "F."), "Tabima", role = "aut",

--- a/NEWS
+++ b/NEWS
@@ -45,6 +45,8 @@ BUG FIX
   (see https://github.com/grunwaldlab/poppr/issues/124).
 * `read.genalex()` will now implicitly check for the correct number of 
   individuals in the data (see https://github.com/grunwaldlab/poppr/issues/128).
+* The function `poppr()` no longer throws an error if the sample > 0 and the 
+  data has no population (see https://github.com/grunwaldlab/poppr/issues/130).
   
 MISC
 ----

--- a/R/Index_calculations.r
+++ b/R/Index_calculations.r
@@ -439,7 +439,7 @@ poppr <- function(dat, total = TRUE, sublist = "ALL", blacklist = NULL,
                  namelist = list(File = namelist$File, population = "Total"),
                  hist = plot
                 )
-    
+    IaList <- if (sample > 0) IaList$index else IaList
     Iout <- as.data.frame(list(
       Pop = "Total",
       N = N.vec,

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -62,7 +62,7 @@
 #'   by missing data in a location should be counted as matching at that 
 #'   location. Default set to \code{TRUE}, which forces missing data to match 
 #'   with anything. \code{FALSE} forces missing data to not match with any other
-#'   information.
+#'   information, \strong{including other missing data}.
 #'   
 #' @param differences_only \code{logical}. When \code{differences_only = TRUE},
 #'   the output will reflect the number of different loci. The default setting,

--- a/R/classes.r
+++ b/R/classes.r
@@ -70,6 +70,12 @@ setClassUnion("mlgORnumeric", c("MLG", "numeric"))
 #'   multilocus genotypes OR it can contain a special internal 
 #'   \code{\linkS4class{MLG}} class that allows for custom multilocus genotype 
 #'   definitions and filtering.
+#' 
+#' @note When calculating multilocus genotypes for genclone objects, a rank 
+#'   function is used, but calculation of multilocus genotypes for snpclone
+#'   objects is distance-based (via \code{\link{bitwise.dist}} and 
+#'   \code{\link{mlg.filter}}). This means that genclone objects are sensitive
+#'   to missing data, whereas snpclone objects are insensitive.
 #'   
 #' @name genclone-class
 #' @rdname genclone-class
@@ -96,7 +102,7 @@ setClassUnion("mlgORnumeric", c("MLG", "numeric"))
 #' #
 #' set.seed(999)
 #' (gl <- glSim(100, 0, n.snp.struc = 1e3, ploidy = 2, parallel = FALSE))
-#' (sc <- as.snpclone(gl, parallel = FALSE))
+#' (sc <- as.snpclone(rbind(gl, gl, parallel = FALSE), parallel = FALSE))
 #' # 
 #' # Use mlg.filter to create a distance threshold to define multilocus genotypes.
 #' mlg.filter(sc, threads = 1L) <- 0.25

--- a/R/internal.r
+++ b/R/internal.r
@@ -2753,13 +2753,10 @@ handle_mlg_index <- function(i, gid){
   if (is.logical(i) || is.numeric(i)){
     return(i)
   }
-  if (is.factor(i)){
-    i <- as.character(i)
-  } else {
-    i <- match(i, indNames(gid))         # match to the index names
-    i <- i[!is.na(i)]                    # remove missing indices
-    i <- if (length(i) == 0) TRUE else i # ignore if no result
-  }
+  i <- if (is.factor(i)) as.character(i) else i
+  i <- match(i, indNames(gid))         # match to the index names
+  i <- i[!is.na(i)]                    # remove missing indices
+  i <- if (length(i) == 0) TRUE else i # ignore if no result
   return(i)
 }
 

--- a/R/internal_methods.R
+++ b/R/internal_methods.R
@@ -269,7 +269,7 @@ mlg.filter.internal <- function(gid, threshold = 0.0, missing = "asis",
   
   if (!is.clone(gid)) {
     if (is(gid, "genlight")){
-      gid <- as.snpclone(gid)
+      gid <- as.snpclone(gid, mlg = seq_len(nInd(gid)))
     } else {
       gid <- as.genclone(gid)
     }

--- a/R/methods.r
+++ b/R/methods.r
@@ -393,7 +393,7 @@ setMethod(
     mlgtype  <- paste0(mlgtype, "multilocus genotypes")
 
     msg <- paste("   @mlg:", length(unique(object@mlg[])), mlgtype)
-    if (mlgtype == "contracted "){
+    if (mlgtype == "contracted multilocus genotypes"){
       thresh <- round(cutoff(object@mlg)["contracted"], 3)
       algo <- strsplit(distalgo(object@mlg), "_")[[1]][1]
       dist <- distname(object@mlg)

--- a/R/methods.r
+++ b/R/methods.r
@@ -386,13 +386,14 @@ setMethod(
     y <- gsub("GENLIGHT", "SNPCLONE", y)
     y <- gsub("/", "|", y)
     genspot <- grepl("@gen", y)
+    ismlg <- inherits(object@mlg, "MLG")
     
-    the_type <- visible(object@mlg)
-    mlgtype  <- ifelse(is(object@mlg, "MLG"), paste0(the_type, " "), "")
+    mlgtype <- if (ismlg) paste0(visible(object@mlg), " ") else ""
+    # mlgtype  <- ifelse(ismlg, paste0(the_type, " "), "")
     mlgtype  <- paste0(mlgtype, "multilocus genotypes")
 
     msg <- paste("   @mlg:", length(unique(object@mlg[])), mlgtype)
-    if (the_type == "contracted"){
+    if (mlgtype == "contracted "){
       thresh <- round(cutoff(object@mlg)["contracted"], 3)
       algo <- strsplit(distalgo(object@mlg), "_")[[1]][1]
       dist <- distname(object@mlg)

--- a/R/methods.r
+++ b/R/methods.r
@@ -324,13 +324,15 @@ is.clone <- function(x){
 #' @param i vector of numerics indicating number of individuals desired
 #' @param j a vector of numerics corresponding to the loci desired.
 #' @param ... passed on to the \code{\linkS4class{genlight}} object.
+#' @param mlg.reset logical. Defaults to \code{FALSE}. If \code{TRUE}, the mlg
+#'   vector will be reset
 #' @param drop set to \code{FALSE} 
 #' @author Zhian N. Kamvar
 #==============================================================================#
 setMethod(
   f = "[",
   signature(x = "snpclone", i = "ANY", j = "ANY", drop = "ANY"),
-  definition = function(x, i, j, ..., drop = FALSE){
+  definition = function(x, i, j, ..., mlg.reset = FALSE, drop = FALSE){
     if (missing(i)) i <- TRUE
 
     # handle MLG indices
@@ -338,11 +340,25 @@ setMethod(
     # Tue Sep 27 12:08:37 2016 ------------------------------
     # Methods for subsetting genind object by sample name currently don't exist
     i          <- handle_mlg_index(i, x)
-    mlg        <- if (ismlgclass) x@mlg[i, all = TRUE] else x@mlg[i]
+    # mlg        <- if (ismlgclass) x@mlg[i, all = TRUE] else x@mlg[i]
     
     # Subset data; replace MLGs    
     x     <- callNextMethod(x = x, i = i, j = j, ..., drop = drop)
-    x@mlg <- mlg
+    if (!mlg.reset){
+      if (inherits(x@mlg, "MLG")){
+        x@mlg <- x@mlg[i, all = TRUE]
+      } else {
+        x@mlg <- x@mlg[i]
+      }
+    } else {
+      if (!inherits(x@mlg, "MLG")){
+        x@mlg <- mlg.vector(x, reset = TRUE)
+      } else {
+        x@mlg <- new("MLG", mlg.vector(x, reset = TRUE))
+      }
+    }
+    
+    # x@mlg <- mlg
     return(x)
   })
 

--- a/R/mlg.r
+++ b/R/mlg.r
@@ -97,6 +97,24 @@
 #' \subsection{mlg.id}{ a list of multilocus genotypes with the associated
 #' individual names per MLG. }
 #' 
+#' @details Multilocus genotypes are the unique combination of alleles across
+#'   all loci. For details of how these are calculated see \code{vignette("mlg",
+#'   package = "poppr")}. In short, for genind and genclone objects, they are
+#'   calculated by using a rank function on strings of alleles, which is
+#'   sensitive to missing data. For genlight and snpclone objects, they are
+#'   calculated with distance methods via \code{\link{bitwise.dist}} and
+#'   \code{\link{mlg.filter}}, which means that these are insensitive to missing
+#'   data. Three different types of MLGs can be defined in \pkg{poppr}: \itemize{ 
+#'   \item{original - }{the default definition of multilocus genotypes as
+#'   detailed above} \item{contracted - }{these are multilocus genotypes
+#'   collapsed into multilocus lineages (\code{\link{mll}}) with genetic
+#'   distance via \code{\link{mlg.filter}}} \item{custom - }{user-defined
+#'   multilocus genotypes. These are useful for information such as mycelial
+#'   compatibility groups}}
+#'   \strong{All of the functions documented here will work on any of the MLG
+#'   types defined in \pkg{poppr}}
+#'   
+#' 
 #' @seealso \code{\link[vegan]{diversity}} 
 #'  \code{\link{diversity_stats}}
 #'  \code{\link{popsub}}
@@ -319,7 +337,7 @@ mlg.vector <- function(gid, reset = FALSE){
     return(mlg.filter(gid, 
                       threshold = .Machine$double.eps ^ 0.5,
                       distance = bitwise.dist,
-                      missing_match = FALSE))
+                      missing_match = TRUE))
   } 
   xtab <- gid@tab
   # concatenating each genotype into one long string.

--- a/R/mlg.r
+++ b/R/mlg.r
@@ -314,8 +314,12 @@ mlg.vector <- function(gid, reset = FALSE){
   if (!reset && is.clone(gid) && length(gid@mlg) == nInd(gid)){
     return(gid@mlg[])
   }
-  if (is(gid, "genlight")){
-    return(seq_len(nInd(gid)))
+  if (inherits(gid, "genlight")){
+    if (is.clone(gid)) gid@mlg <- seq_len(nInd(gid))
+    return(mlg.filter(gid, 
+                      threshold = .Machine$double.eps ^ 0.5,
+                      distance = bitwise.dist,
+                      missing_match = FALSE))
   } 
   xtab <- gid@tab
   # concatenating each genotype into one long string.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Poppr version 2 <img src="vignettes/small_logo.png" align="right"/>
 
-[![Build Status](https://travis-ci.org/grunwaldlab/poppr.svg?branch=master)](https://travis-ci.org/grunwaldlab/poppr)
-[![Coverage Status](https://coveralls.io/repos/grunwaldlab/poppr/badge.svg?branch=master)](https://coveralls.io/r/grunwaldlab/poppr?branch=master)
+[![Build Status](https://travis-ci.org/grunwaldlab/poppr.svg?branch=initialize-snpclone-mlg)](https://travis-ci.org/grunwaldlab/poppr)
+[![Coverage Status](https://coveralls.io/repos/grunwaldlab/poppr/badge.svg?branch=initialize-snpclone-mlg)](https://coveralls.io/r/grunwaldlab/poppr?branch=initialize-snpclone-mlg)
 [![CRAN version](http://www.r-pkg.org/badges/version/poppr)](https://cran.r-project.org/package=poppr)
 <!-- 
 [![Downloads from Rstudio mirror per month](https://cranlogs.r-pkg.org/badges/poppr)](http://www.r-pkg.org/pkg/poppr)

--- a/man/bitwise.dist.Rd
+++ b/man/bitwise.dist.Rd
@@ -22,7 +22,7 @@ represented as integers from 1 to n where n is the number of loci.}
 by missing data in a location should be counted as matching at that 
 location. Default set to \code{TRUE}, which forces missing data to match 
 with anything. \code{FALSE} forces missing data to not match with any other
-information.}
+information, \strong{including other missing data}.}
 
 \item{differences_only}{\code{logical}. When \code{differences_only = TRUE},
 the output will reflect the number of different loci. The default setting,

--- a/man/genclone-class.Rd
+++ b/man/genclone-class.Rd
@@ -34,6 +34,13 @@ The genclone and snpclone classes will allow for more optimized
 object of class \code{\linkS4class{MLG}}.}
 }}
 
+\note{
+When calculating multilocus genotypes for genclone objects, a rank 
+  function is used, but calculation of multilocus genotypes for snpclone
+  objects is distance-based (via \code{\link{bitwise.dist}} and 
+  \code{\link{mlg.filter}}). This means that genclone objects are sensitive
+  to missing data, whereas snpclone objects are insensitive.
+}
 \section{Extends}{
  The \code{genclone} class extends class 
   \code{"\linkS4class{genind}"}, directly. \cr The \code{snpclone} class 
@@ -53,7 +60,7 @@ partial_clone
 #
 set.seed(999)
 (gl <- glSim(100, 0, n.snp.struc = 1e3, ploidy = 2, parallel = FALSE))
-(sc <- as.snpclone(gl, parallel = FALSE))
+(sc <- as.snpclone(rbind(gl, gl, parallel = FALSE), parallel = FALSE))
 # 
 # Use mlg.filter to create a distance threshold to define multilocus genotypes.
 mlg.filter(sc, threads = 1L) <- 0.25

--- a/man/mlg.Rd
+++ b/man/mlg.Rd
@@ -92,6 +92,24 @@ a \code{list} containing vectors of population names for each MLG.
 \description{
 Create counts, vectors, and matrices of multilocus genotypes.
 }
+\details{
+Multilocus genotypes are the unique combination of alleles across
+  all loci. For details of how these are calculated see \code{vignette("mlg",
+  package = "poppr")}. In short, for genind and genclone objects, they are
+  calculated by using a rank function on strings of alleles, which is
+  sensitive to missing data. For genlight and snpclone objects, they are
+  calculated with distance methods via \code{\link{bitwise.dist}} and
+  \code{\link{mlg.filter}}, which means that these are insensitive to missing
+  data. Three different types of MLGs can be defined in \pkg{poppr}: \itemize{ 
+  \item{original - }{the default definition of multilocus genotypes as
+  detailed above} \item{contracted - }{these are multilocus genotypes
+  collapsed into multilocus lineages (\code{\link{mll}}) with genetic
+  distance via \code{\link{mlg.filter}}} \item{custom - }{user-defined
+  multilocus genotypes. These are useful for information such as mycelial
+  compatibility groups}}
+  \strong{All of the functions documented here will work on any of the MLG
+  types defined in \pkg{poppr}}
+}
 \note{
 The resulting matrix of \code{mlg.table} can be used for analysis with 
 the \code{\link{vegan}} package.

--- a/man/snpclone-method.Rd
+++ b/man/snpclone-method.Rd
@@ -7,7 +7,8 @@
 \alias{show,snpclone-method}
 \title{Methods used for the snpclone object}
 \usage{
-\S4method{[}{snpclone,ANY,ANY,ANY}(x, i, j, ..., drop = FALSE)
+\S4method{[}{snpclone,ANY,ANY,ANY}(x, i, j, ..., mlg.reset = FALSE,
+  drop = FALSE)
 
 \S4method{initialize}{snpclone}(.Object, ..., mlg, mlgclass = TRUE)
 
@@ -21,6 +22,9 @@
 \item{j}{a vector of numerics corresponding to the loci desired.}
 
 \item{...}{passed on to the \code{\linkS4class{genlight}} object.}
+
+\item{mlg.reset}{logical. Defaults to \code{FALSE}. If \code{TRUE}, the mlg
+vector will be reset}
 
 \item{drop}{set to \code{FALSE}}
 

--- a/src/bitwise_distance.c
+++ b/src/bitwise_distance.c
@@ -268,6 +268,10 @@ SEXP bitwise_distance_haploid(SEXP genlight, SEXP missing, SEXP requested_thread
 
       // Set R_nap2 to be genlight@gen[[j]]@NA.posi aka a vector of integers 
       // each representing the location of a locus with missing data
+      // 
+      // TODO: use deque to assess shared missing sites between R_nap1 and
+      //       R_nap2 so the behavior is closer to that of mlg.vector for
+      //       genind objects.
       R_nap2 = getAttrib(VECTOR_ELT(R_gen,j),R_nap_symbol);
 
       // Set nap2_length to be the number of loci containing missing data in 

--- a/tests/testthat/test-genclone.R
+++ b/tests/testthat/test-genclone.R
@@ -87,3 +87,9 @@ test_that("subsetting a genclone object retains the MLG definitions", {
   expect_equal(mll(pc[idn]), mll(pc[idl]))
   expect_equal(mll(pc[idi]), mll(pc[idl]))
 })
+
+test_that("genclone objects can be subset with character strings or factors", {
+  idn <- mlg.id(pc)[[1]]
+  idf <- as.factor(idn)
+  expect_equal(mll(pc[idn]), mll(pc[idf]))
+})

--- a/tests/testthat/test-genclone.R
+++ b/tests/testthat/test-genclone.R
@@ -93,3 +93,10 @@ test_that("genclone objects can be subset with character strings or factors", {
   idf <- as.factor(idn)
   expect_equal(mll(pc[idn]), mll(pc[idf]))
 })
+
+test_that("mlg.filter<- works for genclone, but not genind", {
+  skip_on_cran()
+  mlg.filter(pc, distance = nei.dist) <- 0.1
+  expect_equal(nmll(pc), 24)
+  expect_warning(mlg.filter(partial_clone) <- 0.1)
+})

--- a/tests/testthat/test-poppr.R
+++ b/tests/testthat/test-poppr.R
@@ -99,7 +99,7 @@ test_that("poppr perform clone correction", {
 
 test_that("poppr skips over sample sizes less than three", {
   skip_on_cran()
-  expect_output(plt <- poppr(partial_clone[1:8], sample = 10), "^| Total$")
+  expect_warning(plt <- poppr(partial_clone[1:8], sample = 10, quiet = TRUE), "could not be plotted")
   expect_is(plt, "popprtable")
   expect_equivalent(signif(plt$Ia, 3), c(rep(NA, 4), 0.167))
   expect_equivalent(signif(plt$rbarD, 3), c(rep(NA, 4), 0.0195))
@@ -117,4 +117,12 @@ test_that("poppr can produce output from input file", {
 test_that("poppr.all works on list of files", {
   skip_on_cran()
   expect_output(out <- poppr.all(list(afile, pc = partial_clone)), " | File: rootrot.csv")
+})
+
+test_that("poppr without sampling works on data without populations", {
+  skip_on_cran()
+  pop(partial_clone) <- NULL
+  out <- poppr(partial_clone, sample = 9, quiet = TRUE)
+  expect_is(out, "data.frame")
+  expect_equal(nrow(out), 1L)
 })

--- a/tests/testthat/test-snpclone.R
+++ b/tests/testthat/test-snpclone.R
@@ -1,11 +1,14 @@
 context("snpclone coercion tests")
 
 set.seed(999)
-gl <- glSim(50, 0, n.snp.struc = 1e3, ploidy = 2, parallel = FALSE)
-
-indNames(gl) <- paste("sample", seq(nInd(gl)))
-sc           <- as.snpclone(gl, parallel = FALSE)
-mlg.filter(sc, threads = 1L) <- 0.25
+dat            <- matrix(sample(c(0:2), 50*64, replace = TRUE), 50, 64)
+dat[sample(length(dat), 10)] <- NA
+dat2           <- rbind(dat, tail(dat, 10))
+rownames(dat2) <- paste("sample", seq(60))
+colnames(dat2) <- paste("SNP", seq(64))
+gl             <- new("genlight", dat2, parallel = FALSE, n.cores = 1L)
+sc             <- as.snpclone(gl, parallel = FALSE, n.cores = 1L)
+# mlg.filter(sc, threads = 1L) <- 0.25
 
 
 test_that("subsetting a snpclone object retains the MLG definitions", {
@@ -16,10 +19,36 @@ test_that("subsetting a snpclone object retains the MLG definitions", {
   expect_equal(mll(sc[idi]), mll(sc[idl]))
 })
 
-# TODO: test mlg.vector on both gl and sc. They should be the same
+test_that("mlg.vector returns the same value for genlight and snpclone", {
+  skip_on_cran()
+  expect_equal(mlg.vector(gl), mlg.vector(sc))
+})
 
-# TODO: test for mlg.reset argument by assigning mlg = seq_len(nInd(gl)) in as.snpclone
-
+test_that("snpclone objects can be initialized with unique mlgs", {
+  skip_on_cran()
+  scu <- as.snpclone(gl, parallel = FALSE, n.cores = 1L, mlg = seq_len(nInd(gl)))
+  expect_identical(indNames(scu), indNames(sc))
+  expect_identical(locNames(scu), locNames(sc))
+  expect_identical(mll(scu), seq_len(nInd(gl)))
+  expect_identical(mll(scu[mlg.reset = TRUE]), mll(sc))
+})
 # TODO: test for handling of missing data (should be considered new genotype)
+test_that("a single instance of missing data won't induce a new genotype", {
+  skip_on_cran()
+  datm        <- dat2
+  datm[60, 1] <- NA
+  scm         <- as.snpclone(new("genlight", datm, parallel = FALSE, n.cores = 1L),
+                             parallel = FALSE, n.cores = 1L)
+  expect_equal(nmll(scm), 50L)
+})
 
-# TODO: test to see if missing data at the same locus is considered similar or different
+test_that("mlg.filter will reduce the number of multilocus lineages", {
+  skip_on_cran()
+  mlg.filter(sc) <- 0.4
+  expect_equal(nmll(sc), 24)
+})
+
+test_that("mlg.filter<- can't be used for genlight objects", {
+  skip_on_cran()
+  expect_warning(mlg.filter(gl) <- 0.5, "mlg.filter<- only has an effect on snpclone objects.")
+})

--- a/tests/testthat/test-snpclone.R
+++ b/tests/testthat/test-snpclone.R
@@ -1,15 +1,25 @@
 context("snpclone coercion tests")
 
 set.seed(999)
-gc <- as.snpclone(glSim(100, 0, n.snp.struc = 1e3, ploidy = 2, parallel = FALSE), parallel = FALSE)
-indNames(gc) <- paste("sample", seq(nInd(gc)))
-mlg.filter(gc, threads = 1L) <- 0.25
+gl <- glSim(50, 0, n.snp.struc = 1e3, ploidy = 2, parallel = FALSE)
+
+indNames(gl) <- paste("sample", seq(nInd(gl)))
+sc           <- as.snpclone(gl, parallel = FALSE)
+mlg.filter(sc, threads = 1L) <- 0.25
 
 
 test_that("subsetting a snpclone object retains the MLG definitions", {
-  idn <- mlg.id(gc)[[2]]
-  idl <- indNames(gc) %in% idn
+  idn <- mlg.id(sc)[[2]]
+  idl <- indNames(sc) %in% idn
   idi <- which(idl)
-  expect_equal(mll(gc[idn]), mll(gc[idl]))
-  expect_equal(mll(gc[idi]), mll(gc[idl]))
+  expect_equal(mll(sc[idn]), mll(sc[idl]))
+  expect_equal(mll(sc[idi]), mll(sc[idl]))
 })
+
+# TODO: test mlg.vector on both gl and sc. They should be the same
+
+# TODO: test for mlg.reset argument by assigning mlg = seq_len(nInd(gl)) in as.snpclone
+
+# TODO: test for handling of missing data (should be considered new genotype)
+
+# TODO: test to see if missing data at the same locus is considered similar or different


### PR DESCRIPTION
This changes behavior for initializing snpclone objects and calculating MLGs for genlight objects by utilizing `bitwise.dist()` as suggested in #125.