### PR TITLE
Add size legend to MSN

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,12 @@ DEPENDENCIES
 
 * The minimum version of igraph has been set to 1.0.0.
 
+MISC
+----
+
+* The MSN is now plotted last in `plot_poppr_msn()` so additional legends can
+  be added if necessary.
+
 poppr 2.5.0
 ===========
 

--- a/R/internal.r
+++ b/R/internal.r
@@ -3017,32 +3017,42 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
   labs   <- make_circle_labs(mlg_number)
   rads   <- (sqrt(labs) * scale)/200
   
-  # Get the bottom of the pop legend
-  ybot   <- a$rect$top - a$rect$h
+  width    <- a$rect$w
+  height   <- a$rect$h
+  top      <- get_legend_side(a, "top")
+  left     <- get_legend_side(a, "left")
+  right    <- get_legend_side(a, "right")
+  bottom   <- get_legend_side(a, "bottom")
+  
   # Get the space between legend elements
   yspace <- min(abs(diff(a$text$y)))
-  # Create positions of circles vertically
-  circly <- rep(ybot - (2.5 * yspace), length(rads))
   
-  # shift the x position of the circles
-  circlx <- a$rect$left + a$rect$w/4
-  circlx <- make_adjacent_circles(rads) + circlx
+  # Create positions of circles horizontally
+  circlx <- rep(left + (width / 4), length(rads))
+  
+  # shift the y position of the circles
+  cpos   <- make_adjacent_circles(rads)
+  circly <- bottom - (max(cpos) + max(rads))
+  circly <- cpos + circly
   
   # Create the circle legend
-  text(x = a$rect$left + a$rect$w/2, 
-       y = ybot - (yspace), 
-       label = "Samples per Node",
-       cex = 0.75)
-  symbols(x = circlx, 
-          y = circly - rads, 
-          circles = rads, 
-          add = TRUE, 
-          inches = FALSE, 
-          asp = 1)
-  text(x = circlx, 
-       y = circly + (0.1 * yspace), 
-       adj = c(0.5, 0),
-       labels = labs, 
-       font = 2, 
-       cex = 0.75)
+  graphics::text(x     = left, 
+                 y     = bottom - yspace, 
+                 label = "Samples/Node",
+                 adj   = c(0, 0.5),
+                 cex   = 0.75,
+                 font  = 2)
+  
+  graphics::symbols(x       = circlx - rads, 
+                    y       = circly, 
+                    circles = rads, 
+                    add     = TRUE, 
+                    inches  = FALSE, 
+                    asp     = 1)
+  
+  graphics::text(x      = circlx + (0.1 * yspace), 
+                 y      = circly, 
+                 labels = labs, 
+                 adj    = c(0, 0.5),
+                 cex    = 0.75)
 }

--- a/R/internal.r
+++ b/R/internal.r
@@ -3026,7 +3026,8 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
   bottom   <- get_legend_side(a, "bottom")
   
   # Get the space between legend elements
-  yspace <- min(abs(diff(a$text$y)))
+  yspace <- diff(a$text$y)
+  yspace <- if (length(yspace) > 0L) min(abs(yspace)) else 0.05
   xspace <- 0.25 * yspace
   
   # Create positions of circles horizontally

--- a/R/internal.r
+++ b/R/internal.r
@@ -3019,6 +3019,7 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
   
   width    <- a$rect$w
   height   <- a$rect$h
+  txt      <- a$text$x[1]
   top      <- get_legend_side(a, "top")
   left     <- get_legend_side(a, "left")
   right    <- get_legend_side(a, "right")
@@ -3026,13 +3027,17 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
   
   # Get the space between legend elements
   yspace <- min(abs(diff(a$text$y)))
+  xspace <- 0.25 * yspace
   
   # Create positions of circles horizontally
-  circlx <- rep(left + (width / 4), length(rads))
+  diam <- max(rads) * 2
+  big_circles <- diam > abs(txt - left)/2
+  circlx <- if (big_circles) left + diam + xspace else txt
+  circlx <- rep(circlx, length(rads))
   
   # shift the y position of the circles
   cpos   <- make_adjacent_circles(rads)
-  circly <- bottom - (max(cpos) + max(rads))
+  circly <- bottom - ((2.5 * yspace) + max(cpos) + max(rads)/2)
   circly <- cpos + circly
   
   # Create the circle legend
@@ -3040,17 +3045,16 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
                  y     = bottom - yspace, 
                  label = "Samples/Node",
                  adj   = c(0, 0.5),
-                 cex   = 0.75,
-                 font  = 2)
+                 cex   = 0.75)
   
-  graphics::symbols(x       = circlx - rads, 
+  graphics::symbols(x       = circlx - (rads + xspace), 
                     y       = circly, 
                     circles = rads, 
                     add     = TRUE, 
                     inches  = FALSE, 
                     asp     = 1)
   
-  graphics::text(x      = circlx + (0.1 * yspace), 
+  graphics::text(x      = circlx, 
                  y      = circly, 
                  labels = labs, 
                  adj    = c(0, 0.5),

--- a/R/internal.r
+++ b/R/internal.r
@@ -3012,7 +3012,9 @@ get_legend_side <- function(a, side = NULL) {
 #' @return a legend with circles
 #'
 #' @noRd
-make_circle_legend <- function(a, mlg_number, scale = 5){
+make_circle_legend <- function(a, mlg_number, scale = 5, cex = 0.75, 
+                               radmult = 1, xspace = NULL, font = 1, 
+                               pos = NULL){
   # Create example circles for comparison
   labs   <- make_circle_labs(mlg_number)
   rads   <- (sqrt(labs) * scale)/200
@@ -3028,7 +3030,7 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
   # Get the space between legend elements
   yspace <- diff(a$text$y)
   yspace <- if (length(yspace) > 0L) min(abs(yspace)) else 0.05
-  xspace <- 0.25 * yspace
+  xspace <- if (is.null(xspace)) 0.25 * yspace else 2 * xspace * yspace
   
   # Create positions of circles horizontally
   diam <- max(rads) * 2
@@ -3042,15 +3044,18 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
   circly <- cpos + circly
   
   # Create the circle legend
-  graphics::text(x     = left, 
+  xpos <- if (is.null(pos)) left else pos
+  tadj <- if (is.null(pos)) c(0, 0.5) else c(0.5, 0.5)
+  graphics::text(x     = xpos, 
                  y     = bottom - yspace, 
                  label = "Samples/Node",
-                 adj   = c(0, 0.5),
-                 cex   = 0.75)
+                 adj   = tadj,
+                 font  = font,
+                 cex   = cex)
   
-  graphics::symbols(x       = circlx - (rads + xspace), 
+  graphics::symbols(x       = circlx - (rads * radmult + xspace), 
                     y       = circly, 
-                    circles = rads, 
+                    circles = rads * radmult, 
                     add     = TRUE, 
                     inches  = FALSE, 
                     asp     = 1)
@@ -3059,5 +3064,5 @@ make_circle_legend <- function(a, mlg_number, scale = 5){
                  y      = circly, 
                  labels = labs, 
                  adj    = c(0, 0.5),
-                 cex    = 0.75)
+                 cex    = cex)
 }

--- a/R/internal.r
+++ b/R/internal.r
@@ -2964,6 +2964,46 @@ make_circle_labs <- function(mlg_number){
   labs
 }
 
+#' Get the correct side of the legend box
+#'
+#' @param a the result of a "legend" call
+#' @param side either "top", "bottom", "right", or "left"
+#'
+#' @return a vector of at max length 4
+#' @noRd
+#'
+#' @examples
+#' plot(seq(-1, 1), seq(-1, 1), asp = 1)
+#' tr <- legend("topright", fill = "blue", legend = "blue")
+#' tl <- legend("topleft", fill = "blue", legend = "blue")
+#' bl <- legend("bottomleft", fill = "blue", legend = "blue")
+#' br <- legend("bottomright", fill = "blue", legend = "blue")
+#' ce <- legend("center", fill = "blue", legend = "blue")
+#' points(x = get_legend_side(ce, 3:4), 
+#'        y = get_legend_side(ce, 1:2), 
+#'        col = c("red", "blue"))
+#' points(x = get_legend_side(tl, 3:4), 
+#'        y = get_legend_side(tl, 1:2), 
+#'        col = c("red", "blue"))
+#' points(x = get_legend_side(bl, 3:4), 
+#'        y = get_legend_side(bl, 1:2), 
+#'        col = c("red", "blue"))
+#' points(x = get_legend_side(br, 3:4), 
+#'        y = get_legend_side(br, 1:2), 
+#'        col = c("red", "blue"))
+#' points(x = get_legend_side(tr, 3:4), 
+#'        y = get_legend_side(tr, 1:2), 
+#'        col = c("red", "blue"))
+get_legend_side <- function(a, side = NULL) {
+  res <- c(
+    top    = a$rect$top,
+    bottom = a$rect$top  - a$rect$h,
+    right  = a$rect$left + a$rect$w,
+    left   = a$rect$left
+  )
+  return( if (is.null(side)) res else res[side] )
+}
+
 #' Create a circle legend
 #'
 #' @param a the output of a "legend" call

--- a/R/internal.r
+++ b/R/internal.r
@@ -3008,6 +3008,12 @@ get_legend_side <- function(a, side = NULL) {
 #'
 #' @param a the output of a "legend" call
 #' @param mlg_number a vector of integers
+#' @param scale a number by which to multiply the node sizes
+#' @param cex character expansion for the text
+#' @param radmult multiplier for the radius (specifically for [plot_poppr_msn])
+#' @param xspace the defined xspacer (currently is wonky :/)
+#' @param font font for the title
+#' @param pos a numeric position for the title or NULL
 #'
 #' @return a legend with circles
 #'

--- a/R/msn_handlers.R
+++ b/R/msn_handlers.R
@@ -209,7 +209,7 @@ msn_constructor <-
         ...
       )
     }
-    graphics::legend(
+    a <- graphics::legend(
       -1.55,
       1,
       bty = "n",
@@ -219,6 +219,7 @@ msn_constructor <-
       fill = color,
       border = NULL
     )
+    make_circle_legend(a, mlg.number, scale = 5)
   }
   
   V(mst)$size  <- sqrt(mlg.number)

--- a/R/msn_handlers.R
+++ b/R/msn_handlers.R
@@ -216,6 +216,7 @@ msn_constructor <-
       cex = 0.75,
       legend = pnames,
       title = "Populations",
+      title.adj = 0,
       fill = color,
       border = NULL
     )

--- a/R/visualizations.r
+++ b/R/visualizations.r
@@ -1105,8 +1105,11 @@ plot_poppr_msn <- function(x,
     # graph, and one horizontal panel of width 4 and height 0.5 for the greyscale.
     if (pop.leg && !all(is.na(poppr_msn$populations))){
       if (scale.leg){
-        layout(matrix(c(1,2,1,3), ncol = 2, byrow = TRUE),
-               widths = c(1, 4), heights= c(4.5, 0.5))        
+        mat <- matrix(c(1,3,
+                        1,2), 
+                      ncol = 2, 
+                      byrow = TRUE)
+        layout(mat, widths = c(1, 4), heights = c(4.5, 0.5))        
       } else {
         layout(matrix(c(1, 2), ncol = 2), widths = c(1, 4))
       }
@@ -1136,16 +1139,8 @@ plot_poppr_msn <- function(x,
                        x.intersp = 0.45, 
                        y.intersp = yintersperse)
     } else {
-      graphics::layout(matrix(c(1,2), nrow = 2), heights = c(4.5, 0.5))
+      graphics::layout(matrix(c(2, 1), nrow = 2), heights = c(4.5, 0.5))
     }
-    
-    ## PLOT
-    par(mar = c(0,0,0,0))
-    plot.igraph(poppr_msn$graph, 
-                vertex.label = labs, 
-                vertex.size = vsize, 
-                layout = lay, 
-                ...)
     if (scale.leg){
       ## SCALE BAR
       if (quantiles){
@@ -1162,6 +1157,14 @@ plot_poppr_msn <- function(x,
       graphics::axis(3, at = c(0, 0.25, 0.5, 0.75, 1), labels = round(quantile(scales), 3))
       graphics::text(0.5, 0, labels = "DISTANCE", font = 2, cex = 1.5, adj = c(0.5, 0))
     }
+    ## PLOT
+    par(mar = c(0,0,0,0))
+    plot.igraph(poppr_msn$graph, 
+                vertex.label = labs, 
+                vertex.size = vsize, 
+                layout = lay, 
+                ...)
+    
   }
   return(invisible(poppr_msn))
 }

--- a/R/visualizations.r
+++ b/R/visualizations.r
@@ -1095,7 +1095,9 @@ plot_poppr_msn <- function(x,
     graphics::par(def.par)
   })
   
-  if (!pop.leg & !scale.leg){
+  pop.leg <- pop.leg && !all(is.na(poppr_msn$populations))
+  
+  if (!pop.leg && !scale.leg) {
     plot.igraph(poppr_msn$graph, vertex.label = labs, vertex.size = vsize, 
                 layout = lay, ...)
   } else {
@@ -1103,10 +1105,10 @@ plot_poppr_msn <- function(x,
     # Setting up the matrix for plotting. One Vertical panel of width 1 and height
     # 5 for the legend, one rectangular panel of width 4 and height 4.5 for the
     # graph, and one horizontal panel of width 4 and height 0.5 for the greyscale.
-    if (pop.leg && !all(is.na(poppr_msn$populations))){
-      if (scale.leg){
-        mat <- matrix(c(1,3,
-                        1,2), 
+    if (pop.leg) {
+      if (scale.leg) {
+        mat <- matrix(c(1,4,
+                        3,2), 
                       ncol = 2, 
                       byrow = TRUE)
         layout(mat, widths = c(1, 4), heights = c(4.5, 0.5))        
@@ -1121,15 +1123,15 @@ plot_poppr_msn <- function(x,
       too_many_pops   <- as.integer(ceiling(nPop(x)/30))
       pops_correction <- ifelse(too_many_pops > 1, -1, 1)
       yintersperse    <- ifelse(too_many_pops > 1, 0.51, 0.62)
-      graphics::plot(c(0, 2), 
-                     c(0, 1), 
+      graphics::plot(c(-1, 1), 
+                     c(-0.5, 0.5), 
                      type = 'n', 
-                     axes = F, 
+                     axes = FALSE, 
                      xlab = '', 
                      ylab = '',
                      main = 'POPULATION')
     
-      graphics::legend("topleft", 
+      a <- graphics::legend("topleft", 
                        bty = "n", 
                        cex = 1.2^pops_correction,
                        legend = poppr_msn$populations, 
@@ -1138,12 +1140,21 @@ plot_poppr_msn <- function(x,
                        ncol = too_many_pops, 
                        x.intersp = 0.45, 
                        y.intersp = yintersperse)
+      N <- V(poppr_msn$graph)$size * V(poppr_msn$graph)$size
+      make_circle_legend(a = a, 
+                         mlg_number = N, 
+                         scale = sqrt(nodescale), 
+                         cex = 1.2 ^ pops_correction,
+                         radmult = 4,
+                         xspace = 0.45,
+                         font = 2,
+                         pos = 0)
     } else {
       graphics::layout(matrix(c(2, 1), nrow = 2), heights = c(4.5, 0.5))
     }
-    if (scale.leg){
+    if (scale.leg) {
       ## SCALE BAR
-      if (quantiles){
+      if (quantiles) {
         scales <- sort(weights)
       } else {
         scales <- seq(wmin, wmax, l = 1000)
@@ -1158,6 +1169,7 @@ plot_poppr_msn <- function(x,
       graphics::text(0.5, 0, labels = "DISTANCE", font = 2, cex = 1.5, adj = c(0.5, 0))
     }
     ## PLOT
+    if (pop.leg && scale.leg) frame()
     par(mar = c(0,0,0,0))
     plot.igraph(poppr_msn$graph, 
                 vertex.label = labs, 

--- a/R/visualizations.r
+++ b/R/visualizations.r
@@ -711,7 +711,7 @@ info_table <- function(gen, type = c("missing", "ploidy"), percent = TRUE, plot 
 greycurve <- function(data = seq(0, 1, length = 1000), glim = c(0,0.8), 
                       gadj = 3, gweight = 1, scalebar = FALSE){
   gadj <- ifelse(gweight == 1, gadj, -gadj)
-  adjustcurve(data, glim, correction=gadj, show = TRUE, scalebar = scalebar)
+  adjustcurve(data, glim, correction = gadj, show = TRUE, scalebar = scalebar)
 }
 
 


### PR DESCRIPTION
This PR does two things:

1. it plots the MSN last so users can add their own legends/annotations
2. it adds size legends for nodes for both the normal msn functions and `plot_poppr_msn`. This closes #158.

Note: The size legends get shoved to the side in `imsn()`, but it may be something that can't be helped.