### PR TITLE
Change win.ia algorithm

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,8 @@ BUG FIX
 
 * `win.ia()` now has more consistent behavior with chromosome structure and will
   no longer result in an integer overflow 
-  (see https://github.com/grunwaldlab/poppr/issues/179).
+  (see https://github.com/grunwaldlab/poppr/issues/179). Thanks to @MarisaMiller
+  for the detailed bug report.
 
 ALGORITHMIC CHANGE
 ------------------
@@ -42,6 +43,10 @@ NEW FEATURES
 
 * `genind2genalex()` now has an `overwrite` parameter set to `FALSE` to prevent
   accidental overwriting of files. 
+
+* `win.ia()` has a new argument `name_window`, which will give each element in 
+  the result the designation of the terminal position of that window. Thanks to
+  @MarisaMiller for the suggestion!
 
 poppr 2.7.1
 ============

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,32 @@
 poppr 2.8.0
 ===========
 
+BUG FIX
+-------
+
+* `win.ia()` now has more consistent behavior with chromosome structure and will
+  no longer result in an integer overflow 
+  (see https://github.com/grunwaldlab/poppr/issues/179).
+
+ALGORITHMIC CHANGE
+------------------
+
+* `win.ia()` may result in slightly different results because of two changes:
+  1. The windows will now always start at position one on any given chromosome.
+  This will result in some windows at the beginning of chromosomes having a 
+  value of `NA` if the first variant starts beyond the first window. 
+  2. Windows are now calculated for each chromosome independently. The previous
+  version first concatenated chromosomes with at least a window-sized gap 
+  between the chromosomes, but failed to ensure that the window always started
+  at the beginning of the chromosome. This version fixes that issue. 
+  (see https://github.com/grunwaldlab/poppr/issues/179).
+  
+DEPRECATION
+-----------
+
+* The `chromosome_buffer` argument for `win.ia()` has been permanently set to
+  `TRUE` and deprecated as it is no longer used. 
+
 NEW FEATURES
 ------------
 

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -478,28 +478,7 @@ win.ia <- function(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
   return(res_mat)
 }
 
-
-adjust_position <- function(x, chromosome_buffer = TRUE, window){
-  xpos  <- position(x)
-  # Each chromosome has it's own position.
-  # In this case, get large round number for each chromosome break.
-  maxp <- 10^ceiling(log(max(xpos), 10))
-  # The buffer prevents the window from crossing into the next chromosome
-  buffer <- chromosome_buffer*window
-  if (length(unique(pmin(xpos))) < nLoc(x)){
-    lpos <- split(xpos, chromosome(x))
-    for (p in seq(lpos)){
-      # adding the large round number plus a buffer (if applicable). This will
-      # ensure that chromosomes don't overlap.
-      lpos[[p]] <- lpos[[p]] + (maxp*(p - 1)) + (buffer*(p - 1)) + 1
-    }
-    xpos <- unlist(lpos, use.names = FALSE)
-  }
-  position(x) <- xpos  
-  return(x)
-}
-
-#' Title
+#' reposition a vector of SNP positions along chromosomes.
 #'
 #' @param xpos original position of SNPs along chromosomes
 #' @param xchrom factor indicating chromosomal regions

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -428,10 +428,17 @@ win.ia <- function(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
   res_mat <- vector(mode = "numeric", length = nwin)
   if (chromos) res_names <- vector(mode = "character", length = nwin)
   if (!quiet) progbar <- txtProgressBar(style = 3)
-  for (i in seq(nwin)){
-    posns    <- which(xpos %in% winmat[i, 1]:winmat[i, 2])
+  for (i in seq(nwin)) {
+    # Define the window
+    the_window <- winmat[i, 1]:winmat[i, 2]
+    # TODO: 
+    #  - [x] find the positions in the window (using a logical vector)
+    #  - [ ] find how many chromosomes are in the window
+    #  - [ ] create a while loop over the chromosomes
+    #  - [ ] filter x by posns & chrom
+    posns    <- which(xpos %in% the_window)
     last_pos <- posns[length(posns)]
-    if (length(posns) < min.snps){
+    if (length(posns) < min.snps) {
       res_mat[i] <- NA
     } else {
       res_mat[i] <- bitwise.ia(x[, posns], threads = threads)

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -438,20 +438,24 @@ win.ia <- function(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
     # TODO: 
     #  - [x] find the positions in the window (using a logical vector)
     #  - [ ] find how many chromosomes are in the window
-    #  - [ ] create a while loop over the chromosomes
+    #  - [x] create a while loop over the chromosomes
     #  - [ ] filter x by posns & chrom
-    posns    <- which(xpos %in% the_window)
-    last_pos <- posns[length(posns)]
-    if (length(posns) < min.snps) {
-      res_mat[i] <- NA
-    } else {
-      res_mat[i] <- bitwise.ia(x[, posns], threads = threads)
-    }
-    if (chromos && !is.na(last_pos) && length(last_pos) > 0) {
-      res_names[i] <- CHROM[last_pos]
-    }
-    if (!quiet) {
-      setTxtProgressBar(progbar, i/nwin)
+    chromosomes_left <- 1L
+    while (chromosomes_left > 0L) {
+      posns    <- which(xpos %in% the_window)
+      last_pos <- posns[length(posns)]
+      if (length(posns) < min.snps) {
+        res_mat[i] <- NA
+      } else {
+        res_mat[i] <- bitwise.ia(x[, posns], threads = threads)
+      }
+      if (chromos && !is.na(last_pos) && length(last_pos) > 0) {
+        res_names[i] <- CHROM[last_pos]
+      }
+      if (!quiet) {
+        setTxtProgressBar(progbar, i/nwin)
+      }
+      chromosomes_left <- chromosomes_left - 1L
     }
   }
   if (!quiet) cat("\n")

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -440,6 +440,7 @@ win.ia <- function(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
     #  - [x] find how many chromosomes are in the window
     #  - [x] create a while loop over the chromosomes
     #  - [x] filter x by posns & chrom
+    #  - [ ] write test to confirm this is correct.
     posns  <- xpos %in% the_window
     if (chromos) {
       chroms <- unique(CHROM[posns])
@@ -511,6 +512,12 @@ adjust_position <- function(x, chromosome_buffer = TRUE, window){
 #'
 #' @examples
 reposition <- function(xpos, xchrom, nloc, chromosome_buffer = TRUE, window){
+  # TODO:
+  #  - [ ] record first and last positions of chromosomes
+  #  - [ ] record number of SNPs left in the window for the last SNP of a
+  #        given chromosome
+  #  - [ ] record number of windows needed before the first position of the 
+  #        next chromosome
   is_increasing <- if (any(diff(xpos) < 0L)) FALSE else TRUE
   lpos   <- split(xpos, xchrom)
   shifts <- cumsum(vapply(lpos, max, integer(1)))

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -468,6 +468,29 @@ adjust_position <- function(x, chromosome_buffer = TRUE, window){
   position(x) <- xpos  
   return(x)
 }
+
+#' Title
+#'
+#' @param xpos original position of SNPs along chromosomes
+#' @param xchrom factor indicating chromosomal regions
+#' @param nloc number of loci
+#' @param chromosome_buffer an indicator of whether or not to insert a 1.5x window between chromosomes to avoid chromosomes being double counted.
+#' @param window The size of the window
+#'
+#' @return a vector of adjusted integer positions.
+#' @noRd
+#'
+#' @examples
+reposition <- function(xpos, xchrom, nloc, chromosome_buffer = TRUE, window){
+  is_increasing <- if (any(diff(xpos) < 0L)) FALSE else TRUE
+  lpos   <- split(xpos, xchrom)
+  shifts <- cumsum(vapply(lpos, max, integer(1)))
+  if (chromosome_buffer) {
+    shifts <- shifts + cumsum(rep(window, length(shifts)))
+  }
+  shifts <- rep(c(0L, shifts[-length(shifts)]), lengths(lpos))
+  unname(xpos + shifts)
+}
 #==============================================================================#
 #' Calculate random samples of the index of association for genlight objects.
 #' 

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -411,6 +411,10 @@ win.ia <- function(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
   chromos <- !is.null(chromosome(x))
   if (chromos){
     CHROM <- chromosome(x)
+    # TODO: modify adjust_position/reposition to only handle cases when the
+    #       sequence of positions is not continuously increasing (such as the
+    #       situation when the positions are relative to the chromosomes). 
+    #       No adjustment needed. 
     x     <- adjust_position(x, chromosome_buffer, window)
   } else {
     if (any(duplicated(position(x)))){
@@ -443,10 +447,10 @@ win.ia <- function(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
     } else {
       res_mat[i] <- bitwise.ia(x[, posns], threads = threads)
     }
-    if (chromos && !is.na(last_pos) && length(last_pos) > 0){
+    if (chromos && !is.na(last_pos) && length(last_pos) > 0) {
       res_names[i] <- CHROM[last_pos]
     }
-    if (!quiet){
+    if (!quiet) {
       setTxtProgressBar(progbar, i/nwin)
     }
   }

--- a/R/bitwise.r
+++ b/R/bitwise.r
@@ -511,23 +511,23 @@ adjust_position <- function(x, chromosome_buffer = TRUE, window){
 #'
 #' @examples
 reposition <- function(xpos, xchrom, chromosome_buffer = TRUE, window){
-  # TODO:
-  #  - [x] record first and last positions of chromosomes
-  #  - [x] record number of SNPs left in the window for the last SNP of a
-  #        given chromosome
-  #  - [x] record number of windows needed before the first position of the 
-  #        next chromosome
+  # TODO: 
+  #  - [ ] create test to ensure this works
   # Test if the positions are all increasing along the sequence.
   is_increasing <- all(diff(xpos) > 0L)
   # If all positions are increasing and the user does not request a chromosome
   # buffer, then return the original positions.
   if (is_increasing & !chromosome_buffer) return(xpos)
-  
+  #
+  # Split the positions by chromosome and find the maximum position in each
   lpos       <- split(xpos, xchrom)
   ends       <- vapply(lpos, max, integer(1), na.rm = TRUE)
-  # add a window width plus the remainder of the window to the ends.
+  # add the remainder of the window to the ends.
   chromshift <- if (chromosome_buffer) window - (ends %% window) else 0L
   shifts     <- cumsum(ends + chromshift)
+  # repeat the shifts along the length of each chromosome so we can
+  # use vectorized addition. Because we don't need to shift the first
+  # chromosome, we use zero for the first one and ignore the last one.
   shifts     <- rep(c(0L, shifts[-length(shifts)]), lengths(lpos))
   unname(xpos + shifts)
 }

--- a/R/bruvo.r
+++ b/R/bruvo.r
@@ -224,6 +224,7 @@ bruvo.dist <- function(pop, replen = 1, add = TRUE, loss = TRUE, by_locus = FALS
   if (length(replen) < nLoc(pop)){
     replen <- vapply(alleles(pop), function(x) guesslengths(as.numeric(x)), 1)
     warning(repeat_length_warning(replen), immediate. = TRUE)
+    if (interactive()) sleep(2L)
   }
   bruvomat  <- new('bruvomat', pop, replen)
   funk_call <- match.call()
@@ -360,9 +361,10 @@ bruvo.boot <- function(pop, replen = 1, add = TRUE, loss = TRUE, sample = 100,
   # Bruvo's distance depends on the knowledge of the repeat length. If the user
   # does not provide the repeat length, it can be estimated by the smallest
   # repeat difference greater than 1. This is not a preferred method. 
-  if (length(replen) < length(locNames(pop))){
+  if (length(replen) < length(locNames(pop))) {
     replen <- vapply(alleles(pop), function(x) guesslengths(as.numeric(x)), 1)
     warning(repeat_length_warning(replen), immediate. = TRUE)
+    if (interactive()) sleep(2L)
   }
   bootgen <- new('bruvomat', pop, replen)
   # Steps: Create initial tree and then use boot.phylo to perform bootstrap

--- a/man/win.ia.Rd
+++ b/man/win.ia.Rd
@@ -5,7 +5,7 @@
 \title{Calculate windows of the index of association for genlight objects.}
 \usage{
 win.ia(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
-  chromosome_buffer = TRUE)
+  name_window = TRUE, chromosome_buffer = TRUE)
 }
 \arguments{
 \item{x}{a \link[=genlight-class]{genlight} or \link[=snpclone-class]{snpclone} object.}
@@ -23,6 +23,10 @@ cores/CPUs. In most cases this is ideal for speed. Note: this option is
 passed to \code{\link[=bitwise.ia]{bitwise.ia()}} and does not parallelize the windowization process.}
 
 \item{quiet}{if \code{FALSE} (default), a progress bar will be printed to the screen.}
+
+\item{name_window}{if \code{TRUE} (default), the result vector will be named with
+the terminal position of the window. In the case where several chromosomes
+are represented, the position will be appended using a period/full stop.}
 
 \item{chromosome_buffer}{\emph{DEPRECATED} if \code{TRUE} (default), buffers will be placed
 between adjacent chromosomal positions to prevent windows from spanning two
@@ -70,22 +74,24 @@ plot(res, type = "l")
 
 # Converting chromosomal coordinates to tidy data
 library("dplyr")
+library("tidyr")
 res_tidy <- res \%>\% 
   data_frame(rd = ., chromosome = names(.)) \%>\% # create two column data frame
-  group_by(chromosome) \%>\%                      # group data by chromosome
-  mutate(window = row_number()) \%>\%             # windows by chromosome
-  ungroup(chromosome) \%>\%                       # ungroup and reorder
-  mutate(chromosome = factor(chromosome, unique(chromosome))) 
+  separate(chromosome, into = c("chromosome", "position")) \%>\% # get the position info
+  mutate(position = as.integer(position)) \%>\% # force position as integers
+  mutate(chromosome = factor(chromosome, unique(chromosome))) # force order chromosomes
 res_tidy
 
 # Plotting with ggplot2
 library("ggplot2")
-ggplot(res_tidy, aes(x = window, y = rd, color = chromosome)) +
+ggplot(res_tidy, aes(x = position, y = rd, color = chromosome)) +
   geom_line() +
   facet_wrap(~chromosome, nrow = 1) +
   ylab(expression(bar(r)[d])) +
-  xlab("window (100bp)") +
-  theme(legend.position = "bottom")
+  xlab("terminal position of sliding window") +
+  labs(caption = "window size: 100bp") + 
+  theme(axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5)) +
+  theme(legend.position = "top")
 
 }
 

--- a/man/win.ia.Rd
+++ b/man/win.ia.Rd
@@ -8,40 +8,39 @@ win.ia(x, window = 100L, min.snps = 3L, threads = 1L, quiet = FALSE,
   chromosome_buffer = TRUE)
 }
 \arguments{
-\item{x}{a \code{\link{genlight}} or \code{\link{snpclone}} object.}
+\item{x}{a \link[=genlight-class]{genlight} or \link[=snpclone-class]{snpclone} object.}
 
 \item{window}{an integer specifying the size of the window.}
 
-\item{min.snps}{an integer specifying the minimum number of snps allowed per 
+\item{min.snps}{an integer specifying the minimum number of snps allowed per
 window. If a window does not meet this criteria, the value will return as
-NA.}
+\code{NA}.}
 
-\item{threads}{The maximum number of parallel threads to be used within this 
-function. A value of 0 (default) will attempt to use as many threads as
-there are available cores/CPUs. In most cases this is ideal. A value of 1
-will force the function to run serially, which may increase stability on
-some systems. Other values may be specified, but should be used with
-caution.}
+\item{threads}{The maximum number of parallel threads to be used within this
+function. Defaults to 1 thread, in which the function will run serially. A
+value of 0 will attempt to use as many threads as there are available
+cores/CPUs. In most cases this is ideal for speed. Note: this option is
+passed to \code{\link[=bitwise.ia]{bitwise.ia()}} and does not parallelize the windowization process.}
 
-\item{quiet}{if \code{FALSE}, a progress bar will be printed to the screen.}
+\item{quiet}{if \code{FALSE} (default), a progress bar will be printed to the screen.}
 
-\item{chromosome_buffer}{if \code{TRUE} (default), buffers will be placed 
+\item{chromosome_buffer}{\emph{DEPRECATED} if \code{TRUE} (default), buffers will be placed
 between adjacent chromosomal positions to prevent windows from spanning two
 chromosomes.}
 }
 \value{
-Index of association representing the samples in this genlight
-  object.
+A value of the standardized index of association for all windows in
+each chromosome.
 }
 \description{
-Genlight objects can contain millions of loci. Since it does not make much 
+Genlight objects can contain millions of loci. Since it does not make much
 sense to calculate the index of association over that many loci, this
 function will scan windows across the loci positions and calculate the index
 of association.
 }
 \note{
 this will calculate the standardized index of association from Agapow
-2001. See \code{\link{ia}} for details.
+and Burt, 2001. See \code{\link[=ia]{ia()}} for details.
 }
 \examples{
 
@@ -73,7 +72,6 @@ plot(res, type = "l")
 library("dplyr")
 res_tidy <- res \%>\% 
   data_frame(rd = ., chromosome = names(.)) \%>\% # create two column data frame
-  filter(chromosome != "") \%>\%                  # filter out null chromosomes
   group_by(chromosome) \%>\%                      # group data by chromosome
   mutate(window = row_number()) \%>\%             # windows by chromosome
   ungroup(chromosome) \%>\%                       # ungroup and reorder
@@ -93,11 +91,7 @@ ggplot(res_tidy, aes(x = window, y = rd, color = chromosome)) +
 
 }
 \seealso{
-\code{\link[adegenet]{genlight}},
-   \code{\link{snpclone}},
-   \code{\link{samp.ia}},
-   \code{\link{ia}},
-   \code{\link{bitwise.dist}}
+\link[=genlight-class]{genlight}, \link[=snpclone-class]{snpclone}, \code{\link[=ia]{ia()}}, \code{\link[=samp.ia]{samp.ia()}}, \code{\link[=bitwise.dist]{bitwise.dist()}}
 }
 \author{
 Zhian N. Kamvar, Jonah C. Brooks

--- a/tests/testthat/test-winia.R
+++ b/tests/testthat/test-winia.R
@@ -10,9 +10,11 @@ x <- glSim(n.ind = 10, n.snp.nonstruc = 5e2, n.snp.struc = 5e2, ploidy = 2,
 
 test_that("win.ia will throw an error if duplicate positions are found", {
   options(poppr.debug = TRUE)
-  expect_output(x.naive     <- win.ia(x), "[|=]{2,}")
-  position(x) <- chrom_pos
+  expect_output(x.naive     <- win.ia(x, name_window = TRUE), "[|=]{2,}")
   expect_equal(length(x.naive), 10L)
+  expect_named(x.naive, as.character(100 * (1:10)))
+  expect_null(names(win.ia(x, quiet = TRUE, name_window = FALSE)))
+  position(x) <- chrom_pos
   expect_error(win.ia(x), "chromosome")
   options(poppr.debug = FALSE)
 })  
@@ -27,7 +29,8 @@ test_that("win.ia will use chromosome structure", {
   chromosome(x) <- chromo
   x.chrom.bt    <- win.ia(x, quiet = TRUE)
   expect_equal(length(x.chrom.bt), 100L)
-  expect_equal(names(x.chrom.bt), as.character(rep(1:10, each = 10)))
+  winnames <- paste(rep(1:10, each = 10), rep(100*(1:10), 10), sep = ".")
+  expect_equal(names(x.chrom.bt), winnames)
 })
   
 test_that("win.ia will always start at the beginning of the chromosome", {

--- a/tests/testthat/test-winia.R
+++ b/tests/testthat/test-winia.R
@@ -1,41 +1,44 @@
 context("win.ia tests")
-options(poppr.debug = FALSE)
 set.seed(999)
 chrom_pos <- vapply(1:10, function(i) sort(sample(1e3, 100)), integer(100)) %>%
   as.vector()
 chromo    <- rep(1:10, each = 100)
-real_pos  <- chrom_pos + 1000*(chromo - 1) + 1#+ 100*(chromo - 1) + 1  
 set.seed(999)
 x <- glSim(n.ind = 10, n.snp.nonstruc = 5e2, n.snp.struc = 5e2, ploidy = 2, 
            parallel = FALSE)
 
 
 test_that("win.ia will throw an error if duplicate positions are found", {
-  x.naive     <- win.ia(x)
+  options(poppr.debug = TRUE)
+  expect_output(x.naive     <- win.ia(x), "[|=]{2,}")
   position(x) <- chrom_pos
   expect_equal(length(x.naive), 10L)
   expect_error(win.ia(x), "chromosome")
+  options(poppr.debug = FALSE)
 })  
+
+test_that("win.ia will throw a warning if chromosome_buffer is specified", {
+  expect_warning(x.naive <- win.ia(x, quiet = TRUE, chromosome_buffer = FALSE), "deprecated")
+})
 
 test_that("win.ia will use chromosome structure", {
   skip_on_cran()
   position(x)   <- chrom_pos
   chromosome(x) <- chromo
-  x.chrom.bt    <- win.ia(x)
-  expect_equal(sum(is.na(x.chrom.bt) & !is.nan(x.chrom.bt)), 9L)
-  expect_equal(length(x.chrom.bt), 109L)
+  x.chrom.bt    <- win.ia(x, quiet = TRUE)
+  expect_equal(length(x.chrom.bt), 100L)
+  expect_equal(names(x.chrom.bt), as.character(rep(1:10, each = 10)))
 })
   
-test_that("win.ia will take into account chromosome buffer", {
+test_that("win.ia will always start at the beginning of the chromosome", {
   skip_on_cran()
   position(x)   <- chrom_pos
   chromosome(x) <- chromo
-  x.chrom.bf    <- win.ia(x, chromosome_buffer = FALSE)
-  chromosome(x) <- NULL
-  position(x)   <- real_pos
-  x.real        <- win.ia(x)
-  expect_equal(length(x.chrom.bf), 100L)
-  expect_equal(length(x.chrom.bf), length(x.real))
-  expect_equal(x.chrom.bf, x.real, check.attributes = FALSE)
+  x.chrom.bf    <- win.ia(x, window = 300L, quiet = TRUE)
+  x.by.chrom    <- lapply(levels(chromosome(x)), function(i) win.ia(x[, chromosome(x) == i], window = 300L, quiet = TRUE))
+  # There should be 4 windows per chromosome.
+  expect_equal(length(x.chrom.bf), 40L)
+  # Using the function with and without chromosome structure should not matter.
+  expect_equal(x.chrom.bf, unlist(x.by.chrom, use.names = FALSE), check.attributes = FALSE)
+  
 })
-


### PR DESCRIPTION
1. The windows will now always start at position one on any given chromosome.
This will result in some windows at the beginning of chromosomes having a 
value of `NA` if the first variant starts beyond the first window. 

2. Windows are now calculated for each chromosome independently. The previous
version first concatenated chromosomes with at least a window-sized gap 
between the chromosomes, but failed to ensure that the window always started
at the beginning of the chromosome. 
(see https://github.com/grunwaldlab/poppr/issues/179).

Additionally, a penalty for users who don't define repeat lengths for Bruvo's distance is included.