### PR TITLE
Fix readgenalex numeric inds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: poppr
 Type: Package
 Title: Genetic Analysis of Populations with Mixed Reproduction
-Version: 2.8.2
-Date: 2019-03-10
+Version: 2.8.2.99-3
+Date: 2019-04-29
 Authors@R: c(person(c("Zhian", "N."), "Kamvar", role = c("cre", "aut"),
     email = "zkamvar@gmail.com", comment = c(ORCID = "0000-0003-1458-7108")),
     person(c("Javier", "F."), "Tabima", role = "aut",

--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,8 @@ BUG FIX
 
 * `read.genalex()` now correctly parses strata when the user imports data that
   contains duplicated data AND has some individuals named as integers less than
-  the number of samples in the data (prepended by zeroes).
+  the number of samples in the data (prepended by zeroes) 
+  (See https://github.com/grunwaldlab/poppr/pull/202).
 
 poppr 2.8.2
 ===========

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+poppr 2.8.2.99
+===========
+
+BUG FIX
+=======
+
+* `read.genalex()` now correctly parses strata when the user imports data that
+  contains duplicated data AND has some individuals named as integers less than
+  the number of samples in the data (prepended by zeroes).
+
 poppr 2.8.2
 ===========
 

--- a/R/file_handling.r
+++ b/R/file_handling.r
@@ -426,13 +426,14 @@ read.genalex <- function(genalex, ploidy = 2, geo = FALSE, region = FALSE,
   res.gid@call <- gencall
   # Checking for individual name duplications or removals -------------------
   
-  same_names <- any(indNames(res.gid) %in% ind.vec)
-  if (same_names){ # no duplications, only removals
+  same_names <- intersect(indNames(res.gid), ind.vec)
+  if (setequal(same_names, indNames(res.gid))) { # no duplications, only removals
     names(ind.vec) <- ind.vec
     ind.vec        <- ind.vec[indNames(res.gid)]
   } else {         # removals and/or duplciations
     ind.vec <- ind.vec[as.integer(indNames(res.gid))]
     other(res.gid)$original_names <- ind.vec
+    ind.vec <- as.integer(indNames(res.gid))
   }
   pop.vec <- pop.vec %null% pop.vec[ind.vec]
   reg.vec <- reg.vec %null% reg.vec[ind.vec]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Poppr version 2 <img src="man/figures/small_logo.png" align="right"/>
 
 In Development:
-[![Build Status](https://travis-ci.org/grunwaldlab/poppr.svg?branch=master)](https://travis-ci.org/grunwaldlab/poppr)
-[![Coverage Status](https://coveralls.io/repos/grunwaldlab/poppr/badge.svg?branch=master)](https://coveralls.io/r/grunwaldlab/poppr?branch=master)
+[![Build Status](https://travis-ci.org/grunwaldlab/poppr.svg?branch=fix-readgenalex-numeric-inds)](https://travis-ci.org/grunwaldlab/poppr)
+[![Coverage Status](https://coveralls.io/repos/grunwaldlab/poppr/badge.svg?branch=fix-readgenalex-numeric-inds)](https://coveralls.io/r/grunwaldlab/poppr?branch=fix-readgenalex-numeric-inds)
 
 CRAN Status:
 [![CRAN version](http://www.r-pkg.org/badges/version-ago/poppr)](https://cran.r-project.org/package=poppr)

--- a/tests/testthat/test-import.R
+++ b/tests/testthat/test-import.R
@@ -14,6 +14,16 @@ A009	7_09_BB	224	97	159	160	133	156	126	119	147	227	261	134	149
 A006	7_09_BB	224	97	159	160	133	156	126	119	147	235	261	134	149
 A013	7_09_BB	224	97	163	160	133	156	126	119	147	235	257	134	149"
 
+yd <- "13	6	1	6											
+			7_09_BB											
+Ind	Pop	CHMFc4	CHMFc5	CHMFc12	SEA	SED	SEE	SEG	SEI	SEL	SEN	SEP	SEQ	SER
+4	7_09_BB	224	85	163	132	133	156	144	116	143	227	257	142	145
+2	7_09_BB	224	97	159	156	129	156	144	113	143	231	261	136	153
+2	7_09_BB	224	97	159	160	133	156	126	119	147	227	257	134	149
+9	7_09_BB	224	97	159	160	133	156	126	119	147	227	261	134	149
+6	7_09_BB	224	97	159	160	133	156	126	119	147	235	261	134	149
+3	7_09_BB	224	97	163	160	133	156	126	119	147	235	257	134	149"
+
 zz <- "1	6	1	6
 7_09_BB			
 Ind	Pop	CHMFc4	CHMFc5
@@ -23,6 +33,7 @@ A011	7_09_BB	224	97
 A009	7_09_BB	224	97
 A006	7_09_BB	224	97
 A013	7_09_BB	224	97"
+
 
 zzna <- "13	6	1	6											
 			7_09_BB											
@@ -83,6 +94,16 @@ A013	7_09_BB_A013	224	97	163	160	133	156	126	119	147	235	257	134	149"
 
 test_that("basic text connections work", {
 	gen <- read.genalex(textConnection(y), sep = "\t")
+	expect_equivalent(tab(gen), tab(monpop[1:6, drop = TRUE]))
+})
+
+test_that("names are corrected properly", {
+	expect_warning(gen <- read.genalex(textConnection(yd), sep = "\t"),
+                 "duplicate labels detected")
+  expect_false(anyNA(strata(gen)))
+  expect_named(other(gen), "original_names")
+  expect_identical(indNames(gen), as.character(1:6))
+  indNames(gen) <- sprintf("A%03d", c(4, 2, 11, 9, 6, 13))
 	expect_equivalent(tab(gen), tab(monpop[1:6, drop = TRUE]))
 })
 

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -93,8 +93,8 @@ test_that("mlg.table will plot color plot without total", {
 test_that("mlg.table will utilize old versions of dplyr", {
   skip_on_cran()
   options(poppr.old.dplyr = TRUE)
-  expect_silent(x <- mlg.table(Pinf, background = TRUE))
-  expect_silent(x <- mlg.table(Pinf))
+  expect_error(x <- mlg.table(Pinf, background = TRUE), NA)
+  expect_error(x <- mlg.table(Pinf), NA)
   options(poppr.old.dplyr = FALSE)
 })
 


### PR DESCRIPTION
This fixes a weird bug in`read.genalex()` where the strata would be mal-formed if the user imported data with a duplication in the sample names AND the sample names had at least one numeric name that was within the range of the samples prepended by zeroes.

yes, I know it's weird, but it's the truth:

``` r
library('poppr')
#> Loading required package: adegenet
#> Loading required package: ade4
#> Registered S3 methods overwritten by 'ggplot2':
#>   method         from 
#>   [.quosures     rlang
#>   c.quosures     rlang
#>   print.quosures rlang
#> Registered S3 method overwritten by 'spdep':
#>   method   from
#>   plot.mst ape
#> 
#>    /// adegenet 2.1.1 is loaded ////////////
#> 
#>    > overview: '?adegenet'
#>    > tutorials/doc/questions: 'adegenetWeb()' 
#>    > bug reports/feature requests: adegenetIssues()
#> Registered S3 method overwritten by 'pegas':
#>   method      from
#>   print.amova ade4
#> This is poppr version 2.8.2. To get started, type package?poppr
#> OMP parallel support: available
yd <- "13   6   1   6                                           
            7_09_BB                                         
Ind Pop CHMFc4  CHMFc5  CHMFc12 SEA SED SEE SEG SEI SEL SEN SEP SEQ SER
4   7_09_BB 224 85  163 132 133 156 144 116 143 227 257 142 145
2   7_09_BB 224 97  159 156 129 156 144 113 143 231 261 136 153
2   7_09_BB 224 97  159 160 133 156 126 119 147 227 257 134 149
9   7_09_BB 224 97  159 160 133 156 126 119 147 227 261 134 149
6   7_09_BB 224 97  159 160 133 156 126 119 147 235 261 134 149
3   7_09_BB 224 97  163 160 133 156 126 119 147 235 257 134 149"

gen <- read.genalex(textConnection(yd), sep = "\t")
#> Warning in df2genind(gena, ind.names = ind.vec, pop = pop.vec, ploidy =
#> 1, : duplicate labels detected for some individuals; using generic labels
strata(gen)
#>       Pop
#> 1    <NA>
#> 2 7_09_BB
#> 3 7_09_BB
#> 4 7_09_BB
#> 5    <NA>
#> 6 7_09_BB
pop(gen)
#> [1] 7_09_BB 7_09_BB 7_09_BB 7_09_BB 7_09_BB 7_09_BB
#> Levels: 7_09_BB
```

<sup>Created on 2019-04-29 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>