### PR TITLE
Allow users to allow zero alleles

### DIFF
--- a/R/amova.r
+++ b/R/amova.r
@@ -335,8 +335,16 @@ poppr.amova <- function(x, hier = NULL, clonecorrect = FALSE, within = TRUE,
   }
 
   # Splitting haplotypes ----------------------------------------------------
+
+  # Assess if a data set has even (unmixed) ploidy. To do this, get the local
+  # ploidy for each locus by individual, and run tabulate. If all genotypes are
+  # accounted for (i.e. there are no "0" alleles present), then there will be
+  # only one non-zero number in tabulate. 
   #
-  full_ploidy <- if (is_genind) codominant && sum(tabulate(get_local_ploidy(x)) > 0) == 1 else TRUE
+  # NOTE: This is the point where numeric snp data will be rejected for being
+  # split into haplotypes. 
+  even_ploidy <- function(x) sum(tabulate(get_local_ploidy(x)) > 0) == 1
+  full_ploidy <- if (is_genind) codominant && even_ploidy(x) else TRUE
   if (within && heterozygous && codominant && !haploid && full_ploidy) {
     hier <- update(hier, ~./Individual)
     x    <- make_haplotypes(x)

--- a/tests/testthat/test-amova.R
+++ b/tests/testthat/test-amova.R
@@ -264,6 +264,48 @@ test_that("AMOVA will give an extra warning for polyploids with zeroes", {
   expect_warning(res <- poppr.amova(recode_polyploids(pg, addzero = TRUE), ~group/population, within = TRUE), wrn)
 })
 
+context("AMOVA for vcfR-exported snp genind data")
+
+m <- matrix(nrow = 10, ncol = 20)
+set.seed(99)
+strat     <- data.frame(POP = rep(c("A", "B"), 5))
+m[1:5, ]  <- sample(c("00", "01", "11"), 5*20, replace = TRUE, prob = c(0.6, 0.3, 0.1))
+m[6:10, ] <- sample(c("00", "01", "11"), 5*20, replace = TRUE, prob = c(0.2, 0.1, 0.7))
+mm[mm == "00"] <- "AA"
+mm[mm == "01"] <- "AC"
+mm[mm == "11"] <- "CC"
+x <- df2genind(m, strata = strat, ncode = 1)
+y <- df2genind(mm, strata = strat, ncode = 1)
+
+test_that("AMOVA will interpret the SNP data as having ambiguous allele dosage by default", {
+
+  expect_warning({
+    ax <- poppr.amova(x, ~POP, quiet = TRUE)
+  }, "Data with mixed ploidy or ambiguous allele dosage")
+
+  # We expect this to be equivalent to the true snps without asessing
+  # within-sample differences
+  ay <- poppr.amova(y, ~POP, quiet = TRUE, within = FALSE)
+  expect_identical(ax, ay)
+})
+
+
+test_that("AMOVA will account for numeric SNP data if the user specifies so", {
+
+  skip('2019-08-04: Still writing the functionality')
+  
+  op <- getOption('poppr.numeric.snp')
+  options(poppr.numeric.snp = TRUE)
+
+  ax <- poppr.amova(x, ~POP, quiet = TRUE)
+  ay <- poppr.amova(y, ~POP, quiet = TRUE)
+  expect_identical(ax, ay)
+
+  options(poppr.numeric.snp = op)
+
+})
+
+
 context("AMOVA on genlight objects")
 
 set.seed(99)


### PR DESCRIPTION
This all points back to https://github.com/knausb/vcfR/issues/115, which
I had previously forgotten about.

I plan to make a catch for this to allow users to interpret zero as a
valid allele and add documentation on how to turn it on/off.