### PR TITLE
Change branch name; rename option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing to *poppr*
 =======================
 
-Thank you for taking interest in contributing to *poppr*. All are welcome to participate in any way they feel is appropriate as long as the [community code of conduct](CONDUCT.md) is respected :ok_hand:.
+Thank you for taking interest in contributing to *poppr*. All are welcome to participate in any way they feel is appropriate as long as the [community code of conduct](CONDUCT.md) is respected :+1:.
 
 There are four ways you can contribute to the development of poppr: reporting a bug, fixing documentation errors, contributing new code, or commenting on issues/pull requests. Note that the majority of these activities do not require you to be proficient in R.
 
@@ -94,7 +94,7 @@ You can make changes directly on github by clicking the little pencil icon in th
 
 1. fork poppr to your github account
 2. clone poppr to your desktop 
-3. create a new branch from master and push/sync to your repository
+3. create a new branch from main and push/sync to your repository
 4. make and commit your changes
 5. update the documentation with roxygen
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: poppr
 Type: Package
 Title: Genetic Analysis of Populations with Mixed Reproduction
-Version: 2.8.6
+Version: 2.8.7
 Authors@R: c(person(c("Zhian", "N."), "Kamvar", role = c("cre", "aut"),
     email = "zkamvar@gmail.com", comment = c(ORCID = "0000-0003-1458-7108")),
     person(c("Javier", "F."), "Tabima", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+poppr 2.8.7
+==========
+
+DEPRECATION
+-----------
+
+* The argument `blacklist` has been deprecated in favor of `exclude` for the
+  following functions: `bruvo.msn()`, `poppr.msn()`, `clonecorrect()`, `poppr()`, 
+  `mlg.table()`, `mlg.crosspop()`, and `popsub()`. It will be removed in the
+  poppr version 2.9
+
+GITHUB
+------
+
+* The default branch for the repository is now "main", so development versions
+  will install `remotes::install_github("grunwaldlab/poppr@main")`
+
 poppr 2.8.6
 ===========
 

--- a/R/Index_calculations.r
+++ b/R/Index_calculations.r
@@ -69,9 +69,11 @@
 #'   population names (accessed via \code{\link[adegenet]{popNames}}). 
 #'   Defaults to "ALL".
 #'   
-#' @param blacklist a list of character strings or integers to indicate specific
-#'   populations to be removed from analysis. Defaults to NULL.
-#'   
+#' @param exclude a \code{vector} of population names or indexes that the user
+#' wishes to discard. Default to \code{NULL}.
+#'
+#' @param blacklist DEPRECATED, use exclude.
+#'
 #' @param sample an integer indicating the number of permutations desired to 
 #'   obtain p-values. Sampling will shuffle genotypes at each locus to simulate 
 #'   a panmictic population using the observed genotypes. Calculating the 
@@ -301,7 +303,7 @@
 #' }
 #==============================================================================#
 #' @import adegenet ggplot2 vegan
-poppr <- function(dat, total = TRUE, sublist = "ALL", blacklist = NULL, 
+poppr <- function(dat, total = TRUE, sublist = "ALL", exclude = NULL, blacklist = NULL, 
                   sample = 0, method = 1, missing = "ignore", cutoff = 0.05, 
                   quiet = FALSE, clonecorrect = FALSE, strata = 1, keep = 1, 
                   plot = TRUE, hist = TRUE, index = "rbarD", minsamp = 10, 
@@ -322,6 +324,19 @@ poppr <- function(dat, total = TRUE, sublist = "ALL", blacklist = NULL,
   namelist <- NULL
   hist <- plot
   callpop  <- match.call()
+  if (!is.null(blacklist)) {
+    warning(
+      option_deprecated(
+        callpop, 
+        "blacklist", 
+        "exclude", 
+        "2.8.7.", 
+        "Please use `exclude` in the future"
+       ), 
+      immediate. = TRUE
+    )
+    exclude <- blacklist
+  }
   if (!is.na(grep("system.file", callpop)[1])){
     popsplt <- unlist(strsplit(dat, "/"))
     namelist$File <- popsplt[length(popsplt)]
@@ -336,7 +351,7 @@ poppr <- function(dat, total = TRUE, sublist = "ALL", blacklist = NULL,
     poplist       <- NULL
     poplist$Total <- dat
   } else {
-    dat <- popsub(x$GENIND, sublist = sublist, blacklist = blacklist)
+    dat <- popsub(x$GENIND, sublist = sublist, exclude = exclude)
     if (any(levels(pop(dat)) == "")) {
       levels(pop(dat))[levels(pop(dat)) == ""] <- "?"
       warning("missing population factor replaced with '?'")

--- a/R/bruvo.r
+++ b/R/bruvo.r
@@ -536,7 +536,7 @@ bruvo.boot <- function(pop, replen = 1, add = TRUE, loss = TRUE, sample = 100,
 bruvo.msn <- function (gid, replen = 1, add = TRUE, loss = TRUE, 
                        mlg.compute = "original", 
                        palette = topo.colors,
-                       sublist = "All", blacklist = NULL, vertex.label = "MLG", 
+                       sublist = "All", exclude = NULL, blacklist = NULL, vertex.label = "MLG", 
                        gscale = TRUE, glim = c(0,0.8), gadj = 3, gweight = 1, 
                        wscale = TRUE, showplot = TRUE, 
                        include.ties = FALSE, threshold = NULL, 
@@ -550,6 +550,19 @@ bruvo.msn <- function (gid, replen = 1, add = TRUE, loss = TRUE,
   }
   if (!inherits(gid@mlg, "MLG")){
     gid@mlg <- new("MLG", gid@mlg)
+  }
+  if (!is.null(blacklist)) {
+    warning(
+      option_deprecated(
+        match.call(), 
+        "blacklist", 
+        "exclude", 
+        "2.8.7.", 
+        "Please use `exclude` in the future"
+       ), 
+      immediate. = TRUE
+    )
+    exclude <- blacklist
   }
   
   
@@ -572,8 +585,8 @@ bruvo.msn <- function (gid, replen = 1, add = TRUE, loss = TRUE,
   
   gadj <- ifelse(gweight == 1, gadj, -gadj)
 
-  if (toupper(sublist[1]) != "ALL" | !is.null(blacklist)){
-    gid <- popsub(gid, sublist, blacklist)
+  if (toupper(sublist[1]) != "ALL" | !is.null(exclude)){
+    gid <- popsub(gid, sublist, exclude)
   }
 
   # Updating the MLG with filtered data

--- a/R/internal.r
+++ b/R/internal.r
@@ -181,37 +181,37 @@ round.poppr <- Vectorize(function(x){
 # Internal functions utilizing this function:
 # ## none
 #==============================================================================#
-sub_index <- function(pop, sublist="ALL", blacklist=NULL){
+sub_index <- function(pop, sublist="ALL", exclude=NULL){
   numList <- seq(nInd(pop))
   if (is.null(pop(pop))){
     return(numList)
   }
   if(toupper(sublist[1]) == "ALL"){
-    if (is.null(blacklist)){
+    if (is.null(exclude)){
       return(numList)
     } else {
       # filling the sublist with all of the population names.
       sublist <- popNames(pop) 
     }
   }
-  # Treating anything present in blacklist.
-  if (!is.null(blacklist)){
-    # If both the sublist and blacklist are numeric or character.
-    if (is.numeric(sublist) & is.numeric(blacklist) | class(sublist) == class(blacklist)){
-      sublist <- sublist[!sublist %in% blacklist]
-    } else if (is.numeric(sublist) & class(blacklist) == "character"){
-    # if the sublist is numeric and blacklist is a character. eg s=1:10, b="USA"
-      sublist <- sublist[sublist %in% which(!popNames(pop) %in% blacklist)]
+  # Treating anything present in exclude.
+  if (!is.null(exclude)){
+    # If both the sublist and exclude are numeric or character.
+    if (is.numeric(sublist) & is.numeric(exclude) | class(sublist) == class(exclude)){
+      sublist <- sublist[!sublist %in% exclude]
+    } else if (is.numeric(sublist) & class(exclude) == "character"){
+    # if the sublist is numeric and exclude is a character. eg s=1:10, b="USA"
+      sublist <- sublist[sublist %in% which(!popNames(pop) %in% exclude)]
     } else {
       # no sublist specified. Ideal situation
       if(all(popNames(pop) %in% sublist)){
-        sublist <- sublist[-blacklist]
+        sublist <- sublist[-exclude]
       } else {
       # weird situation where the user will specify a certain sublist, yet index
-      # the blacklist numerically. Interpreted as an index of populations in the
+      # the exclude numerically. Interpreted as an index of populations in the
       # whole data set as opposed to the sublist.
-        warning("Blacklist is numeric. Interpreting blacklist as the index of the population in the total data set.")
-        sublist <- sublist[!sublist %in% popNames(pop)[blacklist]]
+        warning("Blacklist is numeric. Interpreting exclude as the index of the population in the total data set.")
+        sublist <- sublist[!sublist %in% popNames(pop)[exclude]]
       }
     }
   }
@@ -224,7 +224,7 @@ sub_index <- function(pop, sublist="ALL", blacklist=NULL){
   }
   sublist <- pop(pop) %in% sublist
   if (sum(sublist) == 0){
-    warning("All items present in Sublist are also present in the Blacklist.\nSubsetting not taking place.")
+    warning("All items present in sublist are also present in exclude.\nSubsetting not taking place.")
     return(seq(nInd(pop)))
   } 
   #cat("Sublist:\n", sublist,"\n")

--- a/R/messages.r
+++ b/R/messages.r
@@ -273,3 +273,12 @@ uninformative_loci_message <- function(pop, glocivals, alocivals, locivals,
   msg <- paste("\n", fmsg, "\n", gmsg, "\n", amsg)
   return(msg)
 }
+
+option_deprecated <- function(the_call, option, replacement, version, extra) {
+  names(the_call)[names(the_call) == option] <- replacement
+  CALL <- as.character(deparse(the_call))
+  msg <- paste("the option", option, "is deprecated as of poppr version")
+  msg <- paste(msg, version, extra)
+  msg <- paste(msg, "\n\nPlease use this as a replacement:\n ", CALL, "\n")
+  msg
+}

--- a/R/mlg.r
+++ b/R/mlg.r
@@ -54,9 +54,11 @@
 #' @param sublist a \code{vector} of population names or indices that the user 
 #'   wishes to keep. Default to "ALL".
 #'   
-#' @param blacklist a \code{vector} of population names or indices that the user
-#'   wishes to discard. Default to \code{NULL}.
-#'   
+#' @param exclude a \code{vector} of population names or indexes that the user
+#' wishes to discard. Default to \code{NULL}.
+#'
+#' @param blacklist DEPRECATED, use exclude.
+#'
 #' @param mlgsub a \code{vector} of multilocus genotype indices with which to 
 #'   subset \code{mlg.table} and \code{mlg.crosspop}. NOTE: The resulting table 
 #'   from \code{mlg.table} will only contain countries with those MLGs
@@ -243,7 +245,7 @@ mlg <- function(gid, quiet=FALSE){
 #' 
 #' @export
 #==============================================================================#
-mlg.table <- function(gid, strata = NULL, sublist = "ALL", blacklist = NULL, 
+mlg.table <- function(gid, strata = NULL, sublist = "ALL", exclude = NULL, blacklist = NULL, 
                       mlgsub = NULL, bar = TRUE, plot = TRUE, total = FALSE, 
                       color = FALSE, background = FALSE, quiet = FALSE){  
   if (!is.genind(gid) & !is(gid, "snpclone")){
@@ -253,6 +255,19 @@ mlg.table <- function(gid, strata = NULL, sublist = "ALL", blacklist = NULL,
   if ("bar" %in% names(the_call)){
     plot <- bar
     warning("In poppr version 2.0, bar is deprecated. Please use plot.")
+  }
+  if (!is.null(blacklist)) {
+    warning(
+      option_deprecated(
+        the_call, 
+        "blacklist", 
+        "exclude", 
+        "2.8.7.", 
+        "Please use `exclude` in the future"
+       ), 
+      immediate. = TRUE
+    )
+    exclude <- blacklist
   }
   the_data <- utils::capture.output(the_call[["gid"]])
   if (!is.null(strata)){
@@ -267,8 +282,8 @@ mlg.table <- function(gid, strata = NULL, sublist = "ALL", blacklist = NULL,
     mlgtab <- mlgtab[which(rowSums(mlgtab) > 0L), , drop = FALSE]
     gid <- popsub(gid, sublist = rownames(mlgtab))
   }
-  if (sublist[1] != "ALL" | !is.null(blacklist)){
-    gid <- popsub(gid, sublist, blacklist)
+  if (sublist[1] != "ALL" | !is.null(exclude)){
+    gid <- popsub(gid, sublist, exclude)
     mlgtab <- mlgtab[popNames(gid), , drop=FALSE]
     rows <- rownames(mlgtab)
   }
@@ -399,10 +414,23 @@ mlg.vector <- function(gid, reset = FALSE){
 #' @export
 #==============================================================================#
 
-mlg.crosspop <- function(gid, strata = NULL, sublist = "ALL", blacklist = NULL, 
+mlg.crosspop <- function(gid, strata = NULL, sublist = "ALL", exclude = NULL, blacklist = NULL, 
                          mlgsub = NULL,
                          indexreturn = FALSE, df = FALSE, quiet = FALSE){
 
+  if (!is.null(blacklist)) {
+    warning(
+      option_deprecated(
+        match.call(), 
+        "blacklist", 
+        "exclude", 
+        "2.8.7.", 
+        "Please use `exclude` in the future"
+       ), 
+      immediate. = TRUE
+    )
+    exclude <- blacklist
+  }
   insufficient_subset <- length(sublist) == 1 && sublist[1] != "ALL"
   insufficient_pop    <- is.null(pop(gid)) || nPop(gid) == 1
   if (insufficient_subset | insufficient_pop){
@@ -420,7 +448,7 @@ mlg.crosspop <- function(gid, strata = NULL, sublist = "ALL", blacklist = NULL,
   if (!is.null(strata)){
     setPop(gid) <- strata
   }
-  subind <- sub_index(gid, sublist, blacklist)
+  subind <- sub_index(gid, sublist, exclude)
   vec    <- vec[subind]
   mlgtab <- mlg.matrix(gid)
 
@@ -442,8 +470,8 @@ mlg.crosspop <- function(gid, strata = NULL, sublist = "ALL", blacklist = NULL,
     mlgs   <- stats::setNames(1:ncol(mlgtab), colnames(mlgtab))
   
   } else {
-    if (sublist[1] != "ALL" | !is.null(blacklist)){
-      gid    <- popsub(gid, sublist, blacklist)
+    if (sublist[1] != "ALL" | !is.null(exclude)){
+      gid    <- popsub(gid, sublist, exclude)
       mlgtab <- mlgtab[popNames(gid), , drop = FALSE]
     }
 

--- a/R/visualizations.r
+++ b/R/visualizations.r
@@ -202,9 +202,11 @@ poppr.plot <- function(sample, pval = c(Ia = 0.05, rbarD = 0.05),
 #' @param sublist a \code{vector} of population names or indexes that the user 
 #'   wishes to keep. Default to "ALL".
 #'   
-#' @param blacklist a \code{vector} of population names or indexes that the user
-#'   wishes to discard. Default to \code{NULL}
-#'   
+#' @param exclude a \code{vector} of population names or indexes that the user
+#' wishes to discard. Default to \code{NULL}.
+#'
+#' @param blacklist DEPRECATED, use exclude.
+#'
 #' @param vertex.label a \code{vector} of characters to label each vertex. There
 #'   are two defaults: \code{"MLG"} will label the nodes with the multilocus 
 #'   genotype from the original data set and \code{"inds"} will label the nodes 
@@ -354,7 +356,7 @@ poppr.plot <- function(sample, pval = c(Ia = 0.05, rbarD = 0.05),
 #' 
 #==============================================================================#
 poppr.msn <- function (gid, distmat, palette = topo.colors, mlg.compute = "original",
-                       sublist = "All", blacklist = NULL, vertex.label = "MLG", 
+                       sublist = "All", exclude = NULL, blacklist = NULL, vertex.label = "MLG", 
                        gscale=TRUE, glim = c(0,0.8), gadj = 3, gweight = 1, 
                        wscale=TRUE, showplot = TRUE, 
                        include.ties = FALSE, threshold = NULL, 
@@ -372,6 +374,19 @@ poppr.msn <- function (gid, distmat, palette = topo.colors, mlg.compute = "origi
   }
   if (!inherits(gid@mlg, "MLG")){
     gid@mlg <- new("MLG", gid@mlg)
+  }
+  if (!is.null(blacklist)) {
+    warning(
+      option_deprecated(
+        match.call(), 
+        "blacklist", 
+        "exclude", 
+        "2.8.7.", 
+        "Please use `exclude` in the future"
+       ), 
+      immediate. = TRUE
+    )
+    exclude <- blacklist
   }
   
   
@@ -408,10 +423,10 @@ poppr.msn <- function (gid, distmat, palette = topo.colors, mlg.compute = "origi
   
   # Subsetting the population -----------------------------------------------
   # This will subset both the population and the matrix. 
-  if (toupper(sublist[1]) != "ALL" | !is.null(blacklist)){
-    sublist_blacklist <- sub_index(gid, sublist, blacklist)
-    distmat <- distmat[sublist_blacklist, sublist_blacklist, drop = FALSE]
-    gid    <- popsub(gid, sublist, blacklist)
+  if (toupper(sublist[1]) != "ALL" | !is.null(exclude)){
+    sublist_exclude <- sub_index(gid, sublist, exclude)
+    distmat <- distmat[sublist_exclude, sublist_exclude, drop = FALSE]
+    gid    <- popsub(gid, sublist, exclude)
   }
 
   # Clone correcting the matrix ---------------------------------------------
@@ -912,7 +927,7 @@ greycurve <- function(data = seq(0, 1, length = 1000), glim = c(0,0.8),
 #' ### Utilizing vectors for palettes
 #' 
 #' data(Pram)
-#' Pram_sub <- popsub(Pram, blacklist = c("Nursery_CA", "Nursery_OR"))
+#' Pram_sub <- popsub(Pram, exclude = c("Nursery_CA", "Nursery_OR"))
 #' 
 #' # Creating the network for the forest
 #' min_span_net_sub <- bruvo.msn(Pram_sub, replen = other(Pram)$REPLEN, 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <!-- badges: start -->
 
-[![Build Status](https://travis-ci.org/grunwaldlab/poppr.svg?branch=master)](https://travis-ci.org/grunwaldlab/poppr)
-[![Coverage Status](https://coveralls.io/repos/grunwaldlab/poppr/badge.svg?branch=master)](https://coveralls.io/r/grunwaldlab/poppr?branch=master)
+[![Build Status](https://travis-ci.org/grunwaldlab/poppr.svg?branch=main)](https://travis-ci.org/grunwaldlab/poppr)
+[![Coverage Status](https://coveralls.io/repos/grunwaldlab/poppr/badge.svg?branch=main)](https://coveralls.io/r/grunwaldlab/poppr?branch=main)
 [![CRAN version](https://www.r-pkg.org/badges/version-ago/poppr)](https://cran.r-project.org/package=poppr)
 [![CRAN check status](https://cranchecks.info/badges/worst/poppr)](https://cran.r-project.org/web/checks/check_results_poppr.html)
 [![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/poppr)](https://www.r-pkg.org/pkg/poppr)
@@ -57,7 +57,7 @@ If you use *poppr* at all, please specify the version and cite:
 
 If you use *poppr* in a presentation please mention it as the *poppr* R package,
 specify the version, and use our logo: 
-[(png)](https://github.com/grunwaldlab/poppr/tree/master/vignettes/jalapeno_logo.png) | [(svg)](https://github.com/grunwaldlab/poppr/tree/master/vignettes/jalapeno_logo.svg).
+[(png)](https://github.com/grunwaldlab/poppr/tree/main/vignettes/jalapeno_logo.png) | [(svg)](https://github.com/grunwaldlab/poppr/tree/main/vignettes/jalapeno_logo.svg).
 
 Additionally, if you use any following functionalities:
 
@@ -104,13 +104,13 @@ To install this package from github, make sure you have the following:
 
 - [Xcode](https://developer.apple.com/xcode) (OSX)
     OR [Rtools](https://cran.r-project.org/bin/windows/Rtools/) (Windows)
-- [devtools](https://github.com/hadley/devtools) (to install, use: `install.packages("devtools")`)
+- [{remotes}](https://github.com/r-lib/remotes) (to install, use: `install.packages("remotes")`)
 
 For Linux users, make sure that the function `getOption("unzip")` returns
 `"unzip"` or `"internal"`. If it doesn't, then run `options(unzip =
 "internal")`.
 
-Once you have devtools and a C compiler installed, you can use the 
+Once you have {remotes} and a C compiler installed, you can use the 
 `install_github()` function to install the current version from github.
 
 #### Stable version
@@ -119,8 +119,12 @@ This release will contain bug fixes and new, documented, and stable features
 that will be included in future releases. Note: if you don't have LaTeX
 installed, you should set `build_vignettes = FALSE`.
 
+> Note: As of 2020-06-12 the default branch is the "main" branch to avoid the
+> "master/slave" terminology. For reference, see the 
+> [IETF draft memo](https://tools.ietf.org/id/draft-knodel-terminology-00.html#rfc.section.1.1.1).
+
 ```R
-devtools::install_github(repo = "grunwaldlab/poppr", build_vignettes = TRUE)
+remotes::install_github(repo = "grunwaldlab/poppr@main", build_vignettes = TRUE)
 library("poppr")
 ```
 
@@ -130,10 +134,10 @@ All new features in testing will be released on different branches. These
 features will be in various stages of development and may or may not be 
 documented. Install with caution. The below command would install features on 
 the branch called "devel". Note that these branches might be out of date
-from the master branch.
+from the main branch.
 
 ```R
-devtools::install_github(repo = "grunwaldlab/poppr@devel", build_vignettes = TRUE)
+remotes::install_github(repo = "grunwaldlab/poppr@devel", build_vignettes = TRUE)
 library("poppr")
 ```
 
@@ -172,7 +176,7 @@ https://grunwaldlab.github.io/Population_Genetics_in_R.
 ## Contributing
 
 Please note that this project is released with a [Contributor Code of
-Conduct](https://github.com/grunwaldlab/poppr/tree/master/CODE_OF_CONDUCT.md). By 
+Conduct](https://github.com/grunwaldlab/poppr/tree/main/CODE_OF_CONDUCT.md). By 
 participating in this project you agree to abide by its
 terms. If you wish to contribute code to *poppr*, please fork the repository and
 create a pull request with your added feature.

--- a/inst/shiny/msn_explorer/server.R
+++ b/inst/shiny/msn_explorer/server.R
@@ -413,12 +413,12 @@ shinyServer(function(input, output, session) {
     match_pops <- the_pops %in% input$sublist
 
     # If the number of population selected is greater than half the total
-    # populations, place the unselected populations in the blacklist argument.
+    # populations, place the unselected populations in the exclude argument.
     half <- ceiling(length(the_pops)/2)
     if (sum(match_pops) < half){
       first_dat <- paste0(dat, "_sub <- popsub(", dat, ", sublist = ", make_dput(input$sublist), ")\n")
     } else {
-      first_dat <- paste0(dat, "_sub <- popsub(", dat, ", blacklist = ", make_dput(the_pops[!match_pops]), ")\n")
+      first_dat <- paste0(dat, "_sub <- popsub(", dat, ", exclude = ", make_dput(the_pops[!match_pops]), ")\n")
     }
     closer   <- paste0("showplot = FALSE, include.ties = ", reticulation(), ")")
     has_no_args <- length(args) == 1 && args == ""

--- a/man/bruvo.msn.Rd
+++ b/man/bruvo.msn.Rd
@@ -14,6 +14,7 @@ bruvo.msn(
   mlg.compute = "original",
   palette = topo.colors,
   sublist = "All",
+  exclude = NULL,
   blacklist = NULL,
   vertex.label = "MLG",
   gscale = TRUE,
@@ -51,8 +52,10 @@ to be used to color the populations on the graph. It defaults to
 \item{sublist}{a \code{vector} of population names or indexes that the user 
 wishes to keep. Default to "ALL".}
 
-\item{blacklist}{a \code{vector} of population names or indexes that the user
-wishes to discard. Default to \code{NULL}}
+\item{exclude}{a \code{vector} of population names or indexes that the user
+wishes to discard. Default to \code{NULL}.}
+
+\item{blacklist}{DEPRECATED, use exclude.}
 
 \item{vertex.label}{a \code{vector} of characters to label each vertex. There
 are two defaults: \code{"MLG"} will label the nodes with the multilocus 

--- a/man/mlg.Rd
+++ b/man/mlg.Rd
@@ -14,6 +14,7 @@ mlg.table(
   gid,
   strata = NULL,
   sublist = "ALL",
+  exclude = NULL,
   blacklist = NULL,
   mlgsub = NULL,
   bar = TRUE,
@@ -30,6 +31,7 @@ mlg.crosspop(
   gid,
   strata = NULL,
   sublist = "ALL",
+  exclude = NULL,
   blacklist = NULL,
   mlgsub = NULL,
   indexreturn = FALSE,
@@ -52,8 +54,10 @@ performed.}
 \item{sublist}{a \code{vector} of population names or indices that the user 
 wishes to keep. Default to "ALL".}
 
-\item{blacklist}{a \code{vector} of population names or indices that the user
+\item{exclude}{a \code{vector} of population names or indexes that the user
 wishes to discard. Default to \code{NULL}.}
+
+\item{blacklist}{DEPRECATED, use exclude.}
 
 \item{mlgsub}{a \code{vector} of multilocus genotype indices with which to 
 subset \code{mlg.table} and \code{mlg.crosspop}. NOTE: The resulting table 

--- a/man/plot_poppr_msn.Rd
+++ b/man/plot_poppr_msn.Rd
@@ -242,7 +242,7 @@ plot_poppr_msn(microbov, micmsn, palette = "terrain.colors", inds = "n",
 ### Utilizing vectors for palettes
 
 data(Pram)
-Pram_sub <- popsub(Pram, blacklist = c("Nursery_CA", "Nursery_OR"))
+Pram_sub <- popsub(Pram, exclude = c("Nursery_CA", "Nursery_OR"))
 
 # Creating the network for the forest
 min_span_net_sub <- bruvo.msn(Pram_sub, replen = other(Pram)$REPLEN, 

--- a/man/poppr.Rd
+++ b/man/poppr.Rd
@@ -8,6 +8,7 @@ poppr(
   dat,
   total = TRUE,
   sublist = "ALL",
+  exclude = NULL,
   blacklist = NULL,
   sample = 0,
   method = 1,
@@ -37,8 +38,10 @@ pooled populations.}
 population names (accessed via \code{\link[adegenet]{popNames}}). 
 Defaults to "ALL".}
 
-\item{blacklist}{a list of character strings or integers to indicate specific
-populations to be removed from analysis. Defaults to NULL.}
+\item{exclude}{a \code{vector} of population names or indexes that the user
+wishes to discard. Default to \code{NULL}.}
+
+\item{blacklist}{DEPRECATED, use exclude.}
 
 \item{sample}{an integer indicating the number of permutations desired to 
 obtain p-values. Sampling will shuffle genotypes at each locus to simulate 

--- a/man/poppr.msn.Rd
+++ b/man/poppr.msn.Rd
@@ -12,6 +12,7 @@ poppr.msn(
   palette = topo.colors,
   mlg.compute = "original",
   sublist = "All",
+  exclude = NULL,
   blacklist = NULL,
   vertex.label = "MLG",
   gscale = TRUE,
@@ -43,8 +44,10 @@ specify which mlg level to calculate the nodes from. See details.}
 \item{sublist}{a \code{vector} of population names or indexes that the user 
 wishes to keep. Default to "ALL".}
 
-\item{blacklist}{a \code{vector} of population names or indexes that the user
-wishes to discard. Default to \code{NULL}}
+\item{exclude}{a \code{vector} of population names or indexes that the user
+wishes to discard. Default to \code{NULL}.}
+
+\item{blacklist}{DEPRECATED, use exclude.}
 
 \item{vertex.label}{a \code{vector} of characters to label each vertex. There
 are two defaults: \code{"MLG"} will label the nodes with the multilocus 

--- a/man/popsub.Rd
+++ b/man/popsub.Rd
@@ -4,7 +4,14 @@
 \alias{popsub}
 \title{Subset data by population}
 \usage{
-popsub(gid, sublist = "ALL", blacklist = NULL, mat = NULL, drop = TRUE)
+popsub(
+  gid,
+  sublist = "ALL",
+  exclude = NULL,
+  blacklist = NULL,
+  mat = NULL,
+  drop = TRUE
+)
 }
 \arguments{
 \item{gid}{a \code{\linkS4class{genind}}, \code{\linkS4class{genclone}},
@@ -13,8 +20,10 @@ popsub(gid, sublist = "ALL", blacklist = NULL, mat = NULL, drop = TRUE)
 \item{sublist}{a \code{vector} of population names or indexes that the user
 wishes to keep. Default to \code{"ALL"}.}
 
-\item{blacklist}{a \code{vector} of population names or indexes that the user
+\item{exclude}{a \code{vector} of population names or indexes that the user
 wishes to discard. Default to \code{NULL}.}
+
+\item{blacklist}{DEPRECATED, use exclude.}
 
 \item{mat}{a \code{matrix} object produced by \code{\link{mlg.table}} to be
 subsetted. If this is present, the subsetted matrix will be returned instead
@@ -38,14 +47,14 @@ data(microbov)
 popNames(microbov)
 
 # Analyze only the populations with exactly 50 individuals
-mic.50 <- popsub(microbov, sublist=c(1:6, 11:15), blacklist=c(3,4,13,14))
+mic.50 <- popsub(microbov, sublist=c(1:6, 11:15), exclude=c(3,4,13,14))
 
 \dontrun{
 # Analyze the first 10 populations, except for "Bazadais"
-mic.10 <- popsub(microbov, sublist=1:10, blacklist="Bazadais")
+mic.10 <- popsub(microbov, sublist=1:10, exclude="Bazadais")
 
 # Take out the two smallest populations
-micbig <- popsub(microbov, blacklist=c("NDama", "Montbeliard"))
+micbig <- popsub(microbov, exclude=c("NDama", "Montbeliard"))
 
 # Analyze the two largest populations
 miclrg <- popsub(microbov, sublist=c("BlondeAquitaine", "Charolais"))

--- a/tests/testthat/test-mlg.R
+++ b/tests/testthat/test-mlg.R
@@ -96,9 +96,13 @@ test_that("multilocus genotype matrix can utilize strata", {
   expect_equal(nrow(pcont), 2)
 })
 
-test_that("mlg.table can take a subset of sublist and blacklist", {
+test_that("mlg.table can take a subset of sublist and exclude", {
   skip_on_cran()
-  nomex <- mlg.table(Pinf, strata = ~Country, sublist = 1:4, blacklist = 3, plot = FALSE)
+  expect_warning({
+    nm <- mlg.table(Pinf, strata = ~Country, sublist = 1:4, blacklist = 3, plot = FALSE)
+  }, 'exclude = 3', fixed = TRUE)
+  nomex <- mlg.table(Pinf, strata = ~Country, sublist = 1:4, exclude = 3, plot = FALSE)
+  expect_identical(nm, nomex)
   expect_equal(nrow(nomex), 3)
   expect_true(!"Mexico" %in% rownames(nomex))
   expect_true(all(rownames(nomex) %in% popNames(setPop(Pinf, ~Country))))
@@ -164,7 +168,7 @@ test_that("mlg.crosspop will work with subsetted genclone objects", {
   expect_warning(z <- mlg.crosspop(Athena, mlgsub = c(14, 2:5), quiet = TRUE), "The following multilocus genotypes are not defined in this dataset: 2, 3, 4, 5")
 })
 
-test_that("mlg.crosspop can take sublist and blacklist", {
+test_that("mlg.crosspop can take sublist and exclude", {
   skip_on_cran()
   strata(Aeut) <- other(Aeut)$population_hierarchy
   agc          <- as.genclone(Aeut)
@@ -176,11 +180,14 @@ test_that("mlg.crosspop can take sublist and blacklist", {
 1L), .Names = c("9", "10")), MLG.32 = structure(c(1L, 1L), .Names = c("7", 
 "9")), MLG.52 = structure(c(1L, 1L), .Names = c("5", "9"))), .Names = c("MLG.13", 
 "MLG.23", "MLG.24", "MLG.32", "MLG.52"))
-  
-  expect_output(show(mlg.crosspop(Athena, blacklist = 1)), "MLG.13: \\(2 inds\\) 8 9")
-  expect_output(show(mlg.crosspop(Athena, blacklist = "1")), "MLG.13: \\(2 inds\\) 8 9")
-  expect_output(show(mlg.crosspop(Athena, sublist = 1:10, blacklist = "1")), "MLG.13: \\(2 inds\\) 8 9")
-  expect_equivalent(mlg.crosspop(Athena, sublist = 1:10, blacklist = "1", quiet = TRUE), expectation)
+  expect_warning({
+    bres <- mlg.crosspop(Athena, sublist = 1:10, blacklist = "1", quiet = TRUE)
+  }, 'exclude = "1"', fixed = TRUE)
+  expect_output(show(mlg.crosspop(Athena, exclude = 1)), "MLG.13: \\(2 inds\\) 8 9")
+  expect_output(show(mlg.crosspop(Athena, exclude = "1")), "MLG.13: \\(2 inds\\) 8 9")
+  expect_output(show(mlg.crosspop(Athena, sublist = 1:10, exclude = "1")), "MLG.13: \\(2 inds\\) 8 9")
+  expect_equivalent(mlg.crosspop(Athena, sublist = 1:10, exclude = "1", quiet = TRUE), expectation)
+  expect_equivalent(bres, expectation)
 })
 
 test_that("mlg.crosspop can return a data frame", {

--- a/tests/testthat/test-popsub.R
+++ b/tests/testthat/test-popsub.R
@@ -36,16 +36,20 @@ test_that("subsetting works with populations", {
   expect_that(indNames(nan48), is_identical_to(indNames(p48)))
   # Rejects unknown populations
   expect_that(popsub(nancycats, 18), gives_warning())
-  # Rejects equivalent blacklist and sublist
+  # Rejects old arguments
+  expect_warning({
+    popsub(nancycats, blacklist = 1:5)
+  }, "exclude = 1:5")
+  # Rejects equivalent exclude and sublist
   ## As numeric
-  expect_that(popsub(nancycats, sublist = 1, blacklist = 1), gives_warning())
+  expect_that(popsub(nancycats, sublist = 1, exclude = 1), gives_warning())
   ## As characters
-  expect_that(popsub(nancycats, sublist = "P01", blacklist = "P01"), gives_warning())
-  expect_that(popsub(nancycats, sublist = "P01", blacklist = 1), gives_warning())
-  expect_that(popsub(nancycats, sublist = 1, blacklist = "P01"), gives_warning())
-  expect_that(popsub(nancycats, sublist = c(4, 8), blacklist = c(4, 8)), 
+  expect_that(popsub(nancycats, sublist = "P01", exclude = "P01"), gives_warning())
+  expect_that(popsub(nancycats, sublist = "P01", exclude = 1), gives_warning())
+  expect_that(popsub(nancycats, sublist = 1, exclude = "P01"), gives_warning())
+  expect_that(popsub(nancycats, sublist = c(4, 8), exclude = c(4, 8)), 
               gives_warning())
-  expect_that(popsub(nancycats, sublist = c(4, 8), blacklist = "P08")@tab, 
+  expect_that(popsub(nancycats, sublist = c(4, 8), exclude = "P08")@tab, 
               equals(p4@tab))
   # numeric and character are the same
   expect_that(popsub(nancycats, c("P04", "P08"), drop = FALSE)@tab, equals(nan48@tab))
@@ -80,16 +84,16 @@ test_that("subsetting works with genclone objects", {
   expect_that(indNames(nan48), is_identical_to(indNames(p48)))
   # Rejects unknown populations
   expect_that(popsub(nancycats, 18), gives_warning())
-  # Rejects equivalent blacklist and sublist
+  # Rejects equivalent exclude and sublist
   ## As numeric
-  expect_that(popsub(nancycats, sublist = 1, blacklist = 1), gives_warning())
+  expect_that(popsub(nancycats, sublist = 1, exclude = 1), gives_warning())
   ## As characters
-  expect_that(popsub(nancycats, sublist = "P01", blacklist = "P01"), gives_warning())
-  expect_that(popsub(nancycats, sublist = "P01", blacklist = 1), gives_warning())
-  expect_that(popsub(nancycats, sublist = 1, blacklist = "P01"), gives_warning())
-  expect_that(popsub(nancycats, sublist = c(4, 8), blacklist = c(4, 8)), 
+  expect_that(popsub(nancycats, sublist = "P01", exclude = "P01"), gives_warning())
+  expect_that(popsub(nancycats, sublist = "P01", exclude = 1), gives_warning())
+  expect_that(popsub(nancycats, sublist = 1, exclude = "P01"), gives_warning())
+  expect_that(popsub(nancycats, sublist = c(4, 8), exclude = c(4, 8)), 
               gives_warning())
-  expect_that(popsub(nancycats, sublist = c(4, 8), blacklist = "P08")@tab, 
+  expect_that(popsub(nancycats, sublist = c(4, 8), exclude = "P08")@tab, 
               equals(p4@tab))
   # numeric and character are the same
   expect_that(popsub(nancycats, c("P04", "P08"), drop = FALSE)@tab, equals(nan48@tab))

--- a/tests/testthat/test-trees.R
+++ b/tests/testthat/test-trees.R
@@ -4,7 +4,7 @@ library("ape")
 data("nancycats", package = "adegenet")
 data("Aeut", package = "poppr")
 
-myFastME     <- function(x) fastme.bal(x, nni = TRUE, spr = FALSE, tbr = TRUE)
+myFastME     <- function(x) fastme.bal(x, nni = TRUE, spr = FALSE)
 
 nan9         <- popsub(nancycats, 9)
 nanreps      <- fix_replen(nancycats, rep(2, 9))

--- a/vignettes/poppr_manual.Rmd
+++ b/vignettes/poppr_manual.Rmd
@@ -1072,14 +1072,14 @@ print_command(funk)
     populations in your data set you wish to **retain**. For example:
     `sublist = c(pop_z, pop_y)` or `sublist = 1:2`.
 
--   `blacklist -` vector of populations or integers representing the
+-   `exclude -` vector of populations or integers representing the
     populations in your data set you wish to **exclude**. This can take
     the same type of arguments as sublist, and can be used in
     conjunction with sublist for when you want a range of populations,
     but know that there is one in there that you do not want to analyze.
-    For example: `sublist = 1:15, blacklist = pop_x`. One very useful
-    thing about the blacklist is that it allows the user to be extremely
-    paranoid about the data. You can set the blacklist to contain
+    For example: `sublist = 1:15, exclude = pop_x`. One very useful
+    thing about the exclude is that it allows the user to be extremely
+    paranoid about the data. You can set the exclude to contain
     populations that are not even in your data set and it will still
     work!
 
@@ -1121,8 +1121,8 @@ You can see that the population factors are correct and that the size of
 the data set is considerably smaller. Let's see the data set without the
 North American countries.
 
-```{r popsub_blacklist}
-v_na_minus <- popsub(H3N2, blacklist = c("USA", "Canada"))
+```{r popsub_exclude}
+v_na_minus <- popsub(H3N2, exclude = c("USA", "Canada"))
 popNames(v_na_minus)
 ```
 Let"s make sure that the number of individuals in both data sets is
@@ -1141,7 +1141,7 @@ any countries in North America. We can easily do this by using the
 ```{r popsub_combine}
 vsort <- sort(popNames(H3N2))[1:10]
 vsort
-valph <- popsub(H3N2, sublist = vsort, blacklist = c("USA", "Canada"))
+valph <- popsub(H3N2, sublist = vsort, exclude = c("USA", "Canada"))
 popNames(valph)
 ```
 
@@ -1578,7 +1578,7 @@ print_command(funk)
 
 -   `sublist -` Populations to include (Defaults to "ALL"). see `popsub()`
 
--   `blacklist -` Populations to exclude. see `popsub()`
+-   `exclude -` Populations to exclude. see `popsub()`
 
 -   `mlgsub -` see `mlg.table()` Only analyze specified MLGs. The
     vector for this flag can be produced by this function as you will
@@ -1667,7 +1667,7 @@ print_command(funk)
 
 -   `sublist -` Populations to include (Defaults to "ALL"). see `popsub()`
 
--   `blacklist -` Populations to exclude. see `popsub()`
+-   `exclude -` Populations to exclude. see `popsub()`
 
 -   `mlgsub -` a vector containing the indices of MLGs you wish to
     subset your table with.


### PR DESCRIPTION
Reference: https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx

I've changed the default branch from "master" to "main" to remove a
metaphor of oppression (if only in a symbolic manner).

If you have a local copy of poppr on your system, you can update the
branch by using the following commands:

 git checkout master
 git branch -m master main
 git fetch
 git branch --unset-upstream
 git branch -u origin/main
 git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main

I've also deprecated "blacklist" in favor of "exclude" because that is a
clearer descriptor of the option.