### PR TITLE
Cran release 2021 03 21

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: ['https://www.gofundme.com/f/the-black-resilience-fund', 'https://www.raicestexas.org/donate/', 'https://sogoreate-landtrust.org/', 'https://www.blacktranstravelfund.com/donate'] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://www.blackresiliencefund.com/', 'https://www.raicestexas.org/donate/', 'https://sogoreate-landtrust.org/', 'https://www.blacktranstravelfund.com/donate'] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
-This package was submitted to CRAN on 2021-02-06.
-Once it is accepted, delete this file and tag the release (commit 1a0aa1b1).
+This package was submitted to CRAN on 2021-03-21.
+Once it is accepted, delete this file and tag the release (commit 261515d7).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: poppr
 Type: Package
 Title: Genetic Analysis of Populations with Mixed Reproduction
-Version: 2.9.0
+Version: 2.9.1
 Authors@R: c(person(c("Zhian", "N."), "Kamvar", role = c("cre", "aut"),
     email = "zkamvar@gmail.com", comment = c(ORCID = "0000-0003-1458-7108")),
     person(c("Javier", "F."), "Tabima", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+poppr 2.9.1
+===========
+
+DEPENDENCY UPDATE
+----------------
+
+* The {phangorn} package is no longer imported. We only used one line of code
+  from the package (upgma), so we copied over the implementation with the 
+  author's permission (@KlausVigo, https://github.com/grunwaldlab/poppr/pull/237).
+
 poppr 2.9.0
 ===========
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,11 @@
-# Poppr version 2.9.0
+# Poppr version 2.9.1
 
-This submission fixes an error occurring on Solaris in two vignettes. The offending code has been removed. 
+This update removes a dependency
 
 ## Test environments
 
-* local macOS install, R 4.0.3
-* local ubuntu 20.04 install, R 4.0.3
+* local macOS install, R 4.0.4
+* local ubuntu 20.04 install, R 4.0.4
 * windows R Under development (unstable) 
 
 ## R CMD check results


### PR DESCRIPTION
This release removes phangorn as a dependency. It will not affect normal poppr usage.

I will merge this once on CRAN.

This will fix #230 