### PR TITLE
Fix `bruvo.between()` test fixture

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
-This package was submitted to CRAN on 2021-03-21.
-Once it is accepted, delete this file and tag the release (commit 261515d7).
+This package was submitted to CRAN on 2021-05-22.
+Once it is accepted, delete this file and tag the release (commit f0601677).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: poppr
 Type: Package
 Title: Genetic Analysis of Populations with Mixed Reproduction
-Version: 2.9.1
+Version: 2.9.2
 Authors@R: c(person(c("Zhian", "N."), "Kamvar", role = c("cre", "aut"),
     email = "zkamvar@gmail.com", comment = c(ORCID = "0000-0003-1458-7108")),
     person(c("Javier", "F."), "Tabima", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+poppr 2.9.2
+===========
+
+CRAN MAINTENANCE
+----------------
+
+* A test for `bruvo.between()` was fixed in a superficial way to avoid an error
+  on CRAN R-devel (@zkamvar, https://github.com/grunwaldlab/poppr/pull/242).
+
 poppr 2.9.1
 ===========
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,11 @@
-# Poppr version 2.9.1
+# Poppr version 2.9.2
 
-This update removes a dependency
+This update fixes a test failure pointed out by CRAN on 2021-05-21
 
 ## Test environments
 
-* local macOS install, R 4.0.4
-* local ubuntu 20.04 install, R 4.0.4
+* local macOS install, R 4.1.0
+* local ubuntu 20.04 install, R 4.1.0
 * windows R Under development (unstable) 
 
 ## R CMD check results

--- a/tests/testthat/test-values.R
+++ b/tests/testthat/test-values.R
@@ -61,11 +61,20 @@ test_that("Bruvo between creates a subset of bruvo's distance", {
   ADDloss <- bruvo.between(querygid, refgid, add = TRUE, loss = FALSE)
   addLOSS <- bruvo.between(querygid, refgid, add = FALSE, loss = TRUE)
   ADDLOSS <- bruvo.between(querygid, refgid, add = TRUE, loss = TRUE)
+  # Create expected distance matrix from bruvo.between()
+  make_AL_expect <- function(n) {
+    as.dist(matrix(
+      c(0,   0,   n, 
+        0,   0, NaN,
+        n, NaN,   0), 
+    nrow = 3, ncol = 3))
+  }
   # Values from Bruvo et. al. (2004)
-  expected_addloss <- as.dist(matrix(c(0, 0, 0.46875000000000, NaN, NaN, NaN), ncol=3, nrow=3))
-  expected_ADDloss <- as.dist(matrix(c(0, 0, 0.458333164453506, NaN, NaN, NaN), ncol=3, nrow=3))
-  expected_addLOSS <- as.dist(matrix(c(0, 0, 0.34374987334013, NaN, NaN, NaN), ncol=3, nrow=3))
-  expected_ADDLOSS <- as.dist(matrix(c(0, 0, 0.401041518896818, NaN, NaN, NaN), ncol=3, nrow=3))
+  expected_addloss <- make_AL_expect(0.46875000000000)
+  expected_addLOSS <- make_AL_expect(0.34374987334013)
+  expected_ADDloss <- make_AL_expect(0.458333164453506)
+  expected_ADDLOSS <- make_AL_expect(0.401041518896818)
+
   expect_equal(addloss[1:2], expected_addloss[1:2])
   expect_equal(is.nan(addloss[3]), TRUE)
   expect_equal(ADDloss[1:2], expected_ADDloss[1:2])


### PR DESCRIPTION
This fixes #241 by updating the test fixture for `bruvo.between()`

It's worth noting that this test was _not incorrect_ numerically because
it was only considering the output from the distance matrix, which was a
lower triangle. Because the values that are recycled end up being thrown
away in the distance object, it was okay for us to construct one without
needing to supply the other side of the matrix.

This fixes the issue by adding a helper function to fill in the correct
values of the matrix and then convert to a distance to avoid the error
thrown by R when not supplying a vector with the correct number of
values for the matrix.